### PR TITLE
KSM fee for RMRK to transfer to Statemine

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -231,7 +231,8 @@
                   },
                   "instructions": "xtokensDest",
                   "asset": {
-                    "assetId": 0,
+                    "originAssetId": 2,
+                    "destAssetId": 0,
                     "location": "KSM-Statemine",
                     "locationPath": "absolute"
                   }


### PR DESCRIPTION
Add option to specify cross chain fee token with the following fields:

originAssetId - asset id on the origin network
destAssetId - asset id on the destination network
location - asset location
locationPath - type of the path for the asset location (absolute, relative, concrete)

We still have an assumption that fee asset id on reserve network is 0 (utility asset)