### PR TITLE
Promote USDT xcm to prod

### DIFF
--- a/chains/v11/chains.json
+++ b/chains/v11/chains.json
@@ -2742,20 +2742,6 @@
                 }
             },
             {
-                "assetId": 13,
-                "symbol": "DAI",
-                "precision": 18,
-                "type": "orml",
-                "priceId": "dai",
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DAI.svg",
-                "typeExtras": {
-                    "currencyIdScale": "0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae",
-                    "currencyIdType": "acala_primitives.currency.CurrencyId",
-                    "existentialDeposit": "10000000000000000",
-                    "transfersEnabled": true
-                }
-            },
-            {
                 "assetId": 14,
                 "symbol": "USDT",
                 "precision": 6,

--- a/chains/v11/chains.json
+++ b/chains/v11/chains.json
@@ -2742,7 +2742,7 @@
                 }
             },
             {
-                "assetId": 14,
+                "assetId": 13,
                 "symbol": "USDT",
                 "precision": 6,
                 "type": "orml",

--- a/chains/v11/chains.json
+++ b/chains/v11/chains.json
@@ -2717,6 +2717,7 @@
                 "assetId": 11,
                 "symbol": "EQ",
                 "precision": 9,
+                "priceId": "equilibrium-token",
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Equilibrium.svg",
                 "typeExtras": {
@@ -2737,6 +2738,34 @@
                     "currencyIdScale": "0x050300",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
                     "existentialDeposit": "100",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 13,
+                "symbol": "DAI",
+                "precision": 18,
+                "type": "orml",
+                "priceId": "dai",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DAI.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "10000000000000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 14,
+                "symbol": "USDT",
+                "precision": 6,
+                "type": "orml",
+                "priceId": "tether",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x050c00",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "10000",
                     "transfersEnabled": true
                 }
             }
@@ -4200,6 +4229,20 @@
                     "existentialDeposit": "147058823529412000",
                     "transfersEnabled": true
                 }
+            },
+            {
+                "assetId": 9,
+                "symbol": "USDT",
+                "precision": 6,
+                "priceId": "tether",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0a000000",
+                    "currencyIdType": "u32",
+                    "existentialDeposit": "10000",
+                    "transfersEnabled": true
+                }
             }
         ],
         "nodes": [
@@ -4946,6 +4989,20 @@
                     "currencyIdScale": "0x0800",
                     "currencyIdType": "node_primitives.currency.CurrencyId",
                     "existentialDeposit": "1000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 3,
+                "symbol": "USDT",
+                "precision": 6,
+                "priceId": "tether",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0802",
+                    "currencyIdType": "node_primitives.currency.CurrencyId",
+                    "existentialDeposit": "1000",
                     "transfersEnabled": true
                 }
             }

--- a/chains/v12/chains.json
+++ b/chains/v12/chains.json
@@ -2727,6 +2727,7 @@
                 "assetId": 11,
                 "symbol": "EQ",
                 "precision": 9,
+                "priceId": "equilibrium-token",
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Equilibrium.svg",
                 "typeExtras": {
@@ -2747,6 +2748,34 @@
                     "currencyIdScale": "0x050300",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
                     "existentialDeposit": "100",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 13,
+                "symbol": "DAI",
+                "precision": 18,
+                "type": "orml",
+                "priceId": "dai",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DAI.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "10000000000000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 14,
+                "symbol": "USDT",
+                "precision": 6,
+                "type": "orml",
+                "priceId": "tether",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x050c00",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "10000",
                     "transfersEnabled": true
                 }
             }
@@ -4212,6 +4241,20 @@
                     "existentialDeposit": "147058823529412000",
                     "transfersEnabled": true
                 }
+            },
+            {
+                "assetId": 9,
+                "symbol": "USDT",
+                "precision": 6,
+                "priceId": "tether",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0a000000",
+                    "currencyIdType": "u32",
+                    "existentialDeposit": "10000",
+                    "transfersEnabled": true
+                }
             }
         ],
         "nodes": [
@@ -4964,6 +5007,20 @@
                     "currencyIdScale": "0x0800",
                     "currencyIdType": "node_primitives.currency.CurrencyId",
                     "existentialDeposit": "1000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 3,
+                "symbol": "USDT",
+                "precision": 6,
+                "priceId": "tether",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0802",
+                    "currencyIdType": "node_primitives.currency.CurrencyId",
+                    "existentialDeposit": "1000",
                     "transfersEnabled": true
                 }
             }

--- a/chains/v12/chains.json
+++ b/chains/v12/chains.json
@@ -2752,7 +2752,7 @@
                 }
             },
             {
-                "assetId": 14,
+                "assetId": 13,
                 "symbol": "USDT",
                 "precision": 6,
                 "type": "orml",

--- a/chains/v12/chains.json
+++ b/chains/v12/chains.json
@@ -2752,20 +2752,6 @@
                 }
             },
             {
-                "assetId": 13,
-                "symbol": "DAI",
-                "precision": 18,
-                "type": "orml",
-                "priceId": "dai",
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DAI.svg",
-                "typeExtras": {
-                    "currencyIdScale": "0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae",
-                    "currencyIdType": "acala_primitives.currency.CurrencyId",
-                    "existentialDeposit": "10000000000000000",
-                    "transfersEnabled": true
-                }
-            },
-            {
                 "assetId": 14,
                 "symbol": "USDT",
                 "precision": 6,

--- a/xcm/v3/transfers.json
+++ b/xcm/v3/transfers.json
@@ -206,7 +206,20 @@
         "instructions": "xtokensReserve"
       }
     },
-    "USDT": {
+    "XRT": {
+      "chainId": "631ccc82a078481584041656af292834e1ae6daab61d2875b4dd0c14bb9b17bc",
+      "multiLocation": {
+        "parachainId": 2048
+      },
+      "reserveFee": {
+        "mode": {
+          "type": "proportional",
+          "value": "1158776"
+        },
+        "instructions": "xtokensReserve"
+      }
+    },
+    "USDT-Statemine": {
       "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
       "multiLocation": {
         "parachainId": 1000,
@@ -221,15 +234,17 @@
         "instructions": "xtokensReserve"
       }
     },
-    "XRT": {
-      "chainId": "631ccc82a078481584041656af292834e1ae6daab61d2875b4dd0c14bb9b17bc",
+    "USDT-Statemint": {
+      "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
       "multiLocation": {
-        "parachainId": 2048
+        "parachainId": 1000,
+        "palletInstance": 50,
+        "generalIndex": "1984"
       },
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "1158776"
+          "value": "341500"
         },
         "instructions": "xtokensReserve"
       }
@@ -695,6 +710,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "3703129681"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 7,
+          "assetLocation": "USDT-Statemine",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+                "assetId": 7,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "341500"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1237,6 +1275,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 17,
+          "assetLocation": "USDT-Statemine",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+                "assetId": 7,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "341500"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },
@@ -1583,6 +1644,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "22000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 10,
+          "assetLocation": "USDT-Statemint",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "125000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -2060,6 +2144,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 14,
+          "assetLocation": "USDT-Statemint",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "125000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },
@@ -2114,7 +2221,7 @@
         },
         {
           "assetId": 7,
-          "assetLocation": "USDT",
+          "assetLocation": "USDT-Statemine",
           "assetLocationPath": {
             "type": "relative"
           },
@@ -2182,7 +2289,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "18186974"
+                    "value": "18379325"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -2455,6 +2562,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 7,
+          "assetLocation": "USDT-Statemine",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+                "assetId": 7,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "341500"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },
@@ -2630,6 +2760,99 @@
                 }
               },
               "type": "xcmpallet-teleport"
+            }
+          ]
+        },
+        {
+          "assetId": 1,
+          "assetLocation": "USDT-Statemint",
+          "assetLocationPath": {
+            "type": "relative"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "5d3c298622d5634ed019bf61ea4b71655030015bde9beb0d6a24743714462c86",
+                "assetId": 2,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "800000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "e61a41c53f5dcd0beb09df93b34402aada44cb05117b71059cce40a2723a4e97",
+                "assetId": 14,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "30000000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
+                "assetId": 10,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "25000000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "fc41b9bd8ef8fe53d58c7ea67c794c7ec9a73daf05e6d54b14ff6342c99ba64c",
+                "assetId": 14,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "10103000000000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b",
+                "assetId": 3,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "10103000000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+                "assetId": 9,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "4700000000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
             }
           ]
         }
@@ -2932,6 +3155,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "333333333333000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 9,
+          "assetLocation": "USDT-Statemine",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+                "assetId": 7,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "341500"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3420,6 +3666,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "22000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 14,
+          "assetLocation": "USDT-Statemint",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "125000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3976,6 +4245,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 4,
+          "assetLocation": "USDT-Statemine",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+                "assetId": 7,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "341500"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },
@@ -4181,6 +4473,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 3,
+          "assetLocation": "USDT-Statemint",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "125000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },
@@ -4365,6 +4680,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "172577"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 9,
+          "assetLocation": "USDT-Statemint",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "125000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v3/transfers.json
+++ b/xcm/v3/transfers.json
@@ -206,20 +206,7 @@
         "instructions": "xtokensReserve"
       }
     },
-    "XRT": {
-      "chainId": "631ccc82a078481584041656af292834e1ae6daab61d2875b4dd0c14bb9b17bc",
-      "multiLocation": {
-        "parachainId": 2048
-      },
-      "reserveFee": {
-        "mode": {
-          "type": "proportional",
-          "value": "1158776"
-        },
-        "instructions": "xtokensReserve"
-      }
-    },
-    "USDT-Statemine": {
+    "USDT": {
       "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
       "multiLocation": {
         "parachainId": 1000,
@@ -234,17 +221,15 @@
         "instructions": "xtokensReserve"
       }
     },
-    "USDT-Statemint": {
-      "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+    "XRT": {
+      "chainId": "631ccc82a078481584041656af292834e1ae6daab61d2875b4dd0c14bb9b17bc",
       "multiLocation": {
-        "parachainId": 1000,
-        "palletInstance": 50,
-        "generalIndex": "1984"
+        "parachainId": 2048
       },
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "175000000"
+          "value": "1158776"
         },
         "instructions": "xtokensReserve"
       }
@@ -710,29 +695,6 @@
                   "mode": {
                     "type": "proportional",
                     "value": "3703129681"
-                  },
-                  "instructions": "xtokensDest"
-                }
-              },
-              "type": "xtokens"
-            }
-          ]
-        },
-        {
-          "assetId": 7,
-          "assetLocation": "USDT-Statemine",
-          "assetLocationPath": {
-            "type": "absolute"
-          },
-          "xcmTransfers": [
-            {
-              "destination": {
-                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
-                "assetId": 7,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "341500"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1275,29 +1237,6 @@
               "type": "xtokens"
             }
           ]
-        },
-        {
-          "assetId": 17,
-          "assetLocation": "USDT-Statemine",
-          "assetLocationPath": {
-            "type": "absolute"
-          },
-          "xcmTransfers": [
-            {
-              "destination": {
-                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
-                "assetId": 7,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "341500"
-                  },
-                  "instructions": "xtokensDest"
-                }
-              },
-              "type": "xtokens"
-            }
-          ]
         }
       ]
     },
@@ -1644,29 +1583,6 @@
                   "mode": {
                     "type": "proportional",
                     "value": "22000"
-                  },
-                  "instructions": "xtokensDest"
-                }
-              },
-              "type": "xtokens"
-            }
-          ]
-        },
-        {
-          "assetId": 10,
-          "assetLocation": "USDT-Statemint",
-          "assetLocationPath": {
-            "type": "absolute"
-          },
-          "xcmTransfers": [
-            {
-              "destination": {
-                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
-                "assetId": 1,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "175000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -2144,29 +2060,6 @@
               "type": "xtokens"
             }
           ]
-        },
-        {
-          "assetId": 14,
-          "assetLocation": "USDT-Statemint",
-          "assetLocationPath": {
-            "type": "absolute"
-          },
-          "xcmTransfers": [
-            {
-              "destination": {
-                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
-                "assetId": 1,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "175000000"
-                  },
-                  "instructions": "xtokensDest"
-                }
-              },
-              "type": "xtokens"
-            }
-          ]
         }
       ]
     },
@@ -2221,7 +2114,7 @@
         },
         {
           "assetId": 7,
-          "assetLocation": "USDT-Statemine",
+          "assetLocation": "USDT",
           "assetLocationPath": {
             "type": "relative"
           },
@@ -2289,7 +2182,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "18379325"
+                    "value": "18186974"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -2562,29 +2455,6 @@
               "type": "xtokens"
             }
           ]
-        },
-        {
-          "assetId": 7,
-          "assetLocation": "USDT-Statemine",
-          "assetLocationPath": {
-            "type": "absolute"
-          },
-          "xcmTransfers": [
-            {
-              "destination": {
-                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
-                "assetId": 7,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "341500"
-                  },
-                  "instructions": "xtokensDest"
-                }
-              },
-              "type": "xtokens"
-            }
-          ]
         }
       ]
     },
@@ -2760,99 +2630,6 @@
                 }
               },
               "type": "xcmpallet-teleport"
-            }
-          ]
-        },
-        {
-          "assetId": 1,
-          "assetLocation": "USDT-Statemint",
-          "assetLocationPath": {
-            "type": "relative"
-          },
-          "xcmTransfers": [
-            {
-              "destination": {
-                "chainId": "5d3c298622d5634ed019bf61ea4b71655030015bde9beb0d6a24743714462c86",
-                "assetId": 2,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "800000"
-                  },
-                  "instructions": "xcmPalletDest"
-                }
-              },
-              "type": "xcmpallet"
-            },
-            {
-              "destination": {
-                "chainId": "e61a41c53f5dcd0beb09df93b34402aada44cb05117b71059cce40a2723a4e97",
-                "assetId": 14,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "30000000"
-                  },
-                  "instructions": "xcmPalletDest"
-                }
-              },
-              "type": "xcmpallet"
-            },
-            {
-              "destination": {
-                "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
-                "assetId": 10,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "25000000"
-                  },
-                  "instructions": "xcmPalletDest"
-                }
-              },
-              "type": "xcmpallet"
-            },
-            {
-              "destination": {
-                "chainId": "fc41b9bd8ef8fe53d58c7ea67c794c7ec9a73daf05e6d54b14ff6342c99ba64c",
-                "assetId": 14,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "1010300"
-                  },
-                  "instructions": "xcmPalletDest"
-                }
-              },
-              "type": "xcmpallet"
-            },
-            {
-              "destination": {
-                "chainId": "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b",
-                "assetId": 3,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "10103"
-                  },
-                  "instructions": "xcmPalletDest"
-                }
-              },
-              "type": "xcmpallet"
-            },
-            {
-              "destination": {
-                "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-                "assetId": 9,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "8202500"
-                  },
-                  "instructions": "xcmPalletDest"
-                }
-              },
-              "type": "xcmpallet"
             }
           ]
         }
@@ -3155,29 +2932,6 @@
                   "mode": {
                     "type": "proportional",
                     "value": "333333333333000000"
-                  },
-                  "instructions": "xtokensDest"
-                }
-              },
-              "type": "xtokens"
-            }
-          ]
-        },
-        {
-          "assetId": 9,
-          "assetLocation": "USDT-Statemine",
-          "assetLocationPath": {
-            "type": "absolute"
-          },
-          "xcmTransfers": [
-            {
-              "destination": {
-                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
-                "assetId": 7,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "341500"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3666,29 +3420,6 @@
                   "mode": {
                     "type": "proportional",
                     "value": "22000"
-                  },
-                  "instructions": "xtokensDest"
-                }
-              },
-              "type": "xtokens"
-            }
-          ]
-        },
-        {
-          "assetId": 14,
-          "assetLocation": "USDT-Statemint",
-          "assetLocationPath": {
-            "type": "absolute"
-          },
-          "xcmTransfers": [
-            {
-              "destination": {
-                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
-                "assetId": 1,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "175000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -4245,29 +3976,6 @@
               "type": "xtokens"
             }
           ]
-        },
-        {
-          "assetId": 4,
-          "assetLocation": "USDT-Statemine",
-          "assetLocationPath": {
-            "type": "absolute"
-          },
-          "xcmTransfers": [
-            {
-              "destination": {
-                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
-                "assetId": 7,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "341500"
-                  },
-                  "instructions": "xtokensDest"
-                }
-              },
-              "type": "xtokens"
-            }
-          ]
         }
       ]
     },
@@ -4473,29 +4181,6 @@
               "type": "xtokens"
             }
           ]
-        },
-        {
-          "assetId": 3,
-          "assetLocation": "USDT-Statemint",
-          "assetLocationPath": {
-            "type": "absolute"
-          },
-          "xcmTransfers": [
-            {
-              "destination": {
-                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
-                "assetId": 1,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "175000000"
-                  },
-                  "instructions": "xtokensDest"
-                }
-              },
-              "type": "xtokens"
-            }
-          ]
         }
       ]
     },
@@ -4680,29 +4365,6 @@
                   "mode": {
                     "type": "proportional",
                     "value": "172577"
-                  },
-                  "instructions": "xtokensDest"
-                }
-              },
-              "type": "xtokens"
-            }
-          ]
-        },
-        {
-          "assetId": 9,
-          "assetLocation": "USDT-Statemint",
-          "assetLocationPath": {
-            "type": "absolute"
-          },
-          "xcmTransfers": [
-            {
-              "destination": {
-                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
-                "assetId": 1,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "175000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v3/transfers.json
+++ b/xcm/v3/transfers.json
@@ -244,7 +244,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "341500"
+          "value": "175000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -1666,7 +1666,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "125000000"
+                    "value": "175000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -2159,7 +2159,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "125000000"
+                    "value": "175000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -2819,7 +2819,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "10103000000000"
+                    "value": "1010300"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -2833,7 +2833,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "10103000000"
+                    "value": "10103"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -2847,7 +2847,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "4700000000"
+                    "value": "8202500"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -3688,7 +3688,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "125000000"
+                    "value": "175000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -4488,7 +4488,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "125000000"
+                    "value": "175000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -4702,7 +4702,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "125000000"
+                    "value": "175000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v4/transfers.json
+++ b/xcm/v4/transfers.json
@@ -206,7 +206,20 @@
         "instructions": "xtokensReserve"
       }
     },
-    "USDT": {
+    "XRT": {
+      "chainId": "631ccc82a078481584041656af292834e1ae6daab61d2875b4dd0c14bb9b17bc",
+      "multiLocation": {
+        "parachainId": 2048
+      },
+      "reserveFee": {
+        "mode": {
+          "type": "proportional",
+          "value": "1158776"
+        },
+        "instructions": "xtokensReserve"
+      }
+    },
+    "USDT-Statemine": {
       "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
       "multiLocation": {
         "parachainId": 1000,
@@ -221,15 +234,17 @@
         "instructions": "xtokensReserve"
       }
     },
-    "XRT": {
-      "chainId": "631ccc82a078481584041656af292834e1ae6daab61d2875b4dd0c14bb9b17bc",
+    "USDT-Statemint": {
+      "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
       "multiLocation": {
-        "parachainId": 2048
+        "parachainId": 1000,
+        "palletInstance": 50,
+        "generalIndex": "1984"
       },
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "1158776"
+          "value": "341500"
         },
         "instructions": "xtokensReserve"
       }
@@ -695,6 +710,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "3703129681"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 7,
+          "assetLocation": "USDT-Statemine",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+                "assetId": 7,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "341500"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1237,6 +1275,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 17,
+          "assetLocation": "USDT-Statemine",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+                "assetId": 7,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "341500"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },
@@ -1583,6 +1644,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "22000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 10,
+          "assetLocation": "USDT-Statemint",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "125000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -2060,6 +2144,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 14,
+          "assetLocation": "USDT-Statemint",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "125000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },
@@ -2114,7 +2221,7 @@
         },
         {
           "assetId": 7,
-          "assetLocation": "USDT",
+          "assetLocation": "USDT-Statemine",
           "assetLocationPath": {
             "type": "relative"
           },
@@ -2182,7 +2289,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "18186974"
+                    "value": "18379325"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -2455,6 +2562,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 7,
+          "assetLocation": "USDT-Statemine",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+                "assetId": 7,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "341500"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },
@@ -2630,6 +2760,99 @@
                 }
               },
               "type": "xcmpallet-teleport"
+            }
+          ]
+        },
+        {
+          "assetId": 1,
+          "assetLocation": "USDT-Statemint",
+          "assetLocationPath": {
+            "type": "relative"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "5d3c298622d5634ed019bf61ea4b71655030015bde9beb0d6a24743714462c86",
+                "assetId": 2,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "800000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "e61a41c53f5dcd0beb09df93b34402aada44cb05117b71059cce40a2723a4e97",
+                "assetId": 14,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "30000000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
+                "assetId": 10,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "25000000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "fc41b9bd8ef8fe53d58c7ea67c794c7ec9a73daf05e6d54b14ff6342c99ba64c",
+                "assetId": 14,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "10103000000000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b",
+                "assetId": 3,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "10103000000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+                "assetId": 9,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "4700000000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
             }
           ]
         }
@@ -2932,6 +3155,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "333333333333000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 9,
+          "assetLocation": "USDT-Statemine",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+                "assetId": 7,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "341500"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3420,6 +3666,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "22000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 14,
+          "assetLocation": "USDT-Statemint",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "125000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3976,6 +4245,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 4,
+          "assetLocation": "USDT-Statemine",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+                "assetId": 7,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "341500"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },
@@ -4181,6 +4473,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 3,
+          "assetLocation": "USDT-Statemint",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "125000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },
@@ -4365,6 +4680,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "172577"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 9,
+          "assetLocation": "USDT-Statemint",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "125000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v4/transfers.json
+++ b/xcm/v4/transfers.json
@@ -244,7 +244,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "341500"
+          "value": "175000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -1666,7 +1666,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "125000000"
+                    "value": "175000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -2159,7 +2159,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "125000000"
+                    "value": "175000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -2819,7 +2819,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "10103000000000"
+                    "value": "1010300"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -2833,7 +2833,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "10103000000"
+                    "value": "10103"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -2847,7 +2847,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "4700000000"
+                    "value": "8202500"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -3688,7 +3688,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "125000000"
+                    "value": "175000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -4488,7 +4488,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "125000000"
+                    "value": "175000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -4702,7 +4702,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "125000000"
+                    "value": "175000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
That PR adds:

- new USDT assets (proofs can be found here - https://github.com/nova-wallet/nova-utils/pull/1680#issue-1731582194)
- USDT-Statemint XCM transfers
- Fix for update script (case with deletion)
- Found that EQ has not price on Acala network - "priceId": "equilibrium-token",
- Restore USDT-Statemine XCM transfers
