### PR TITLE
fix BSC wss node

### DIFF
--- a/chains/v11/chains_dev.json
+++ b/chains/v11/chains_dev.json
@@ -7579,7 +7579,7 @@
                 "name": "BSC testnet node 2s3"
             },
             {
-                "url": "wss://testnet.binance.vision/ws/T9GZDMY62FYZRG11Z1CVQ6T1F7XAKRPRAE",
+                "url": "wss://bsc.getblock.io/62f28655-8038-43cc-abca-7d1fb47d7d97/testnet/",
                 "name": "BSC test rpc node"
             }
         ],

--- a/chains/v12/chains_dev.json
+++ b/chains/v12/chains_dev.json
@@ -7620,8 +7620,8 @@
                 "name": "BSC testnet node 2s3"
             },
             {
-                "url": "wss://testnet.binance.vision/ws/T9GZDMY62FYZRG11Z1CVQ6T1F7XAKRPRAE",
-                "name": "BSC test rpc node"
+                "url": "wss://bsc.getblock.io/62f28655-8038-43cc-abca-7d1fb47d7d97/testnet/",
+                "name": "Get block wss node"
             }
         ],
         "explorers": [


### PR DESCRIPTION
Checked by script: https://github.com/novasamatech/support-utils/pull/36/files

The `wss://testnet.binance.vision/ws/T9GZDMY62FYZRG11Z1CVQ6T1F7XAKRPRAE` node does not support required methods:

```bash
Call: eth_getTransactionReceipt - ❌:
{"error":{"code":2,"msg":"Invalid request: unknown variant `eth_getTransactionReceipt`, expected one of `SUBSCRIBE`, `UNSUBSCRIBE`, `LIST_SUBSCRIPTIONS`, `SET_PROPERTY`, `GET_PROPERTY` at line 1 column 56"},"id":1}
```

Added node `wss://bsc.getblock.io/62f28655-8038-43cc-abca-7d1fb47d7d97/testnet/` is support that:

```bash
Call: eth_getTransactionReceipt - ✅
Response is: {'error': {'code': -32602, 'message': 'missing value for required argument 0'}, 'id': 1, 'jsonrpc': '2.0'}
Call: eth_call - ✅
Response is: {'error': {'code': -32602, 'message': 'missing value for required argument 0'}, 'id': 1, 'jsonrpc': '2.0'}
Call: eth_getBalance - ✅
Response is: {'error': {'code': -32602, 'message': 'missing value for required argument 0'}, 'id': 1, 'jsonrpc': '2.0'}
Call: eth_getBlockByNumber - ✅
Response is: {'error': {'code': -32602, 'message': 'missing value for required argument 0'}, 'id': 1, 'jsonrpc': '2.0'}
Call: eth_subscribe - ✅
Response is: {'error': {'code': -32602, 'message': 'too many arguments, want at most 1'}, 'id': 1, 'jsonrpc': '2.0'}
Call: eth_getTransactionReceipt - ✅
Response is: {'error': {'code': -32602, 'message': 'missing value for required argument 0'}, 'id': 1, 'jsonrpc': '2.0'}
Call: eth_call - ✅
Response is: {'error': {'code': -32602, 'message': 'missing value for required argument 0'}, 'id': 1, 'jsonrpc': '2.0'}
Call: eth_getBalance - ✅
Response is: {'error': {'code': -32602, 'message': 'missing value for required argument 0'}, 'id': 1, 'jsonrpc': '2.0'}
Call: eth_getBlockByNumber - ✅
Response is: {'error': {'code': -32602, 'message': 'missing value for required argument 0'}, 'id': 1, 'jsonrpc': '2.0'}
Call: eth_subscribe - ✅
Response is: {'error': {'code': -32602, 'message': 'too many arguments, want at most 1'}, 'id': 1, 'jsonrpc': '2.0'}
```