### PR TITLE
Fix bscscaner url, usdt and usdc assets

### DIFF
--- a/assets/evm/v2/assets_dev.json
+++ b/assets/evm/v2/assets_dev.json
@@ -17,10 +17,6 @@
             {
                 "chainId": "eip155:1",
                 "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7"
-            },
-            {
-                "chainId": "eip155:56",
-                "contractAddress": "0x55d398326f99059fF775485246999027B3197955"
             }
         ]
     },
@@ -42,10 +38,6 @@
             {
                 "chainId": "eip155:1",
                 "contractAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-            },
-            {
-                "chainId": "eip155:56",
-                "contractAddress": "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d"
             }
         ]
     },
@@ -510,6 +502,32 @@
             {
                 "chainId": "eip155:56",
                 "contractAddress": "0xBf5140A22578168FD562DCcF235E5D43A02ce9B1"
+            }
+        ]
+    },
+    {
+        "symbol": "USDT",
+        "precision": 18,
+        "name": "Tether USD",
+        "priceId": "tether",
+        "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",
+        "instances": [
+            {
+                "chainId": "eip155:56",
+                "contractAddress": "0x55d398326f99059fF775485246999027B3197955"
+            }
+        ]
+    },
+    {
+        "symbol": "USDC",
+        "precision": 18,
+        "name": "USD Coin",
+        "priceId": "usd-coin",
+        "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDC.svg",
+        "instances": [
+            {
+                "chainId": "eip155:56",
+                "contractAddress": "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d"
             }
         ]
     }

--- a/chains/v11/chains_dev.json
+++ b/chains/v11/chains_dev.json
@@ -7649,8 +7649,8 @@
         "explorers": [
             {
                 "name": "BscScan",
-                "extrinsic": "https://testnet.bscscan.com/tx/{hash}",
-                "account": "https://testnet.bscscan.com/address/{address}",
+                "extrinsic": "https://bscscan.com/tx/{hash}",
+                "account": "https://bscscan.com/address/{address}",
                 "event": null
             },
             {

--- a/chains/v12/chains_dev.json
+++ b/chains/v12/chains_dev.json
@@ -7690,8 +7690,8 @@
         "explorers": [
             {
                 "name": "BscScan",
-                "extrinsic": "https://testnet.bscscan.com/tx/{hash}",
-                "account": "https://testnet.bscscan.com/address/{address}",
+                "extrinsic": "https://bscscan.com/tx/{hash}",
+                "account": "https://bscscan.com/address/{address}",
                 "event": null
             },
             {


### PR DESCRIPTION
This PR fixes:
* BscScaner url for mainnet
* BEP-20: USDT and USDC assets for having different decimals
Proofs:
[USDT](https://bscscan.com/token/0x55d398326f99059ff775485246999027b3197955)
[USDC](https://bscscan.com/token/0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d)