### PR TITLE
Kabocha network status

### DIFF
--- a/chains/v11/chains.json
+++ b/chains/v11/chains.json
@@ -5364,7 +5364,7 @@
     {
         "chainId": "feb426ca713f0f46c96465b8f039890370cf6bfd687c9076ea2843f58a6ae8a7",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-        "name": "Kabocha (PAUSED)",
+        "name": "Kabocha",
         "assets": [
             {
                 "assetId": 0,

--- a/chains/v11/chains_dev.json
+++ b/chains/v11/chains_dev.json
@@ -6048,7 +6048,7 @@
     {
         "chainId": "feb426ca713f0f46c96465b8f039890370cf6bfd687c9076ea2843f58a6ae8a7",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-        "name": "Kabocha (PAUSED)",
+        "name": "Kabocha",
         "assets": [
             {
                 "assetId": 0,

--- a/chains/v12/chains.json
+++ b/chains/v12/chains.json
@@ -5384,7 +5384,7 @@
     {
         "chainId": "feb426ca713f0f46c96465b8f039890370cf6bfd687c9076ea2843f58a6ae8a7",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-        "name": "Kabocha (PAUSED)",
+        "name": "Kabocha",
         "assets": [
             {
                 "assetId": 0,

--- a/chains/v12/chains_dev.json
+++ b/chains/v12/chains_dev.json
@@ -6093,7 +6093,7 @@
     {
         "chainId": "feb426ca713f0f46c96465b8f039890370cf6bfd687c9076ea2843f58a6ae8a7",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-        "name": "Kabocha (PAUSED)",
+        "name": "Kabocha",
         "assets": [
             {
                 "assetId": 0,


### PR DESCRIPTION
Kabocha is now once again producing blocks – so (PAUSED) status can be removed.

https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkabocha.jelliedowl.net#/explorer