### PR TITLE
feat: promote lptokens, qtokens on Interlay, Kintsugi

### DIFF
--- a/chains/v12/chains.json
+++ b/chains/v12/chains.json
@@ -3567,7 +3567,7 @@
             },
             {
                 "assetId": 6,
-                "symbol": "KSM-kBTC",
+                "symbol": "LP KSM-kBTC",
                 "precision": 18,
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KSM-KBTC.svg",
@@ -3580,7 +3580,7 @@
             },
             {
                 "assetId": 7,
-                "symbol": "kBTC-USDT",
+                "symbol": "LP kBTC-USDT",
                 "precision": 18,
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KBTC-USDT.svg",
@@ -3593,12 +3593,54 @@
             },
             {
                 "assetId": 8,
-                "symbol": "KSM-KINT",
+                "symbol": "LP KSM-KINT",
                 "precision": 18,
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KSM-KINT.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x03000a000c",
+                    "currencyIdType": "interbtc_primitives.CurrencyId",
+                    "existentialDeposit": "0",
+                    "transfersEnabled": false
+                }
+            },
+            {
+                "assetId": 9,
+                "symbol": "qkBTC",
+                "precision": 8,
+                "priceId": "bitcoin",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KBTC.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0201000000",
+                    "currencyIdType": "interbtc_primitives.CurrencyId",
+                    "existentialDeposit": "0",
+                    "transfersEnabled": false
+                }
+            },
+            {
+                "assetId": 10,
+                "symbol": "qKSM",
+                "precision": 12,
+                "priceId": "kusama",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Kusama.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0202000000",
+                    "currencyIdType": "interbtc_primitives.CurrencyId",
+                    "existentialDeposit": "0",
+                    "transfersEnabled": false
+                }
+            },
+            {
+                "assetId": 11,
+                "symbol": "qUSDT",
+                "precision": 6,
+                "priceId": "tether",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0203000000",
                     "currencyIdType": "interbtc_primitives.CurrencyId",
                     "existentialDeposit": "0",
                     "transfersEnabled": false
@@ -4428,6 +4470,87 @@
                     "currencyIdType": "interbtc_primitives.CurrencyId",
                     "existentialDeposit": "0",
                     "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 8,
+                "symbol": "LP iBTC-USDT",
+                "precision": 18,
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/iBTC-USDT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0300010102000000",
+                    "currencyIdType": "interbtc_primitives.CurrencyId",
+                    "existentialDeposit": "0",
+                    "transfersEnabled": false
+                }
+            },
+            {
+                "assetId": 9,
+                "symbol": "LP DOT-iBTC",
+                "precision": 18,
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DOT-iBTC.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0300000001",
+                    "currencyIdType": "interbtc_primitives.CurrencyId",
+                    "existentialDeposit": "0",
+                    "transfersEnabled": false
+                }
+            },
+            {
+                "assetId": 10,
+                "symbol": "LP INTR-USDT",
+                "precision": 18,
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/INTR-USDT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0300020102000000",
+                    "currencyIdType": "interbtc_primitives.CurrencyId",
+                    "existentialDeposit": "0",
+                    "transfersEnabled": false
+                }
+            },
+            {
+                "assetId": 11,
+                "symbol": "qiBTC",
+                "precision": 8,
+                "priceId": "bitcoin",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/interBTC.svg",
+                "type": "orml",
+                "typeExtras": {
+                    "currencyIdScale": "0x0201000000",
+                    "currencyIdType": "interbtc_primitives.CurrencyId",
+                    "existentialDeposit": "0",
+                    "transfersEnabled": false
+                }
+            },
+            {
+                "assetId": 12,
+                "symbol": "qUSDT",
+                "precision": 6,
+                "priceId": "tether",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",
+                "type": "orml",
+                "typeExtras": {
+                    "currencyIdScale": "0x0203000000",
+                    "currencyIdType": "interbtc_primitives.CurrencyId",
+                    "existentialDeposit": "0",
+                    "transfersEnabled": false
+                }
+            },
+            {
+                "assetId": 13,
+                "symbol": "qDOT",
+                "precision": 10,
+                "priceId": "polkadot",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Polkadot.svg",
+                "type": "orml",
+                "typeExtras": {
+                    "currencyIdScale": "0x0202000000",
+                    "currencyIdType": "interbtc_primitives.CurrencyId",
+                    "existentialDeposit": "0",
+                    "transfersEnabled": false
                 }
             }
         ],

--- a/chains/v12/chains_dev.json
+++ b/chains/v12/chains_dev.json
@@ -1797,48 +1797,6 @@
             },
             {
                 "assetId": 9,
-                "symbol": "INTR",
-                "precision": 10,
-                "priceId": "interlay",
-                "type": "orml",
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Interlay.svg",
-                "typeExtras": {
-                    "currencyIdScale": "0x0002",
-                    "currencyIdType": "interbtc_primitives.CurrencyId",
-                    "existentialDeposit": "0",
-                    "transfersEnabled": true
-                }
-            },
-            {
-                "assetId": 10,
-                "symbol": "iBTC",
-                "precision": 8,
-                "priceId": "bitcoin",
-                "type": "orml",
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/interBTC.svg",
-                "typeExtras": {
-                    "currencyIdScale": "0x0001",
-                    "currencyIdType": "interbtc_primitives.CurrencyId",
-                    "existentialDeposit": "0",
-                    "transfersEnabled": true
-                }
-            },
-            {
-                "assetId": 11,
-                "symbol": "DOT",
-                "precision": 10,
-                "priceId": "polkadot",
-                "type": "orml",
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Polkadot.svg",
-                "typeExtras": {
-                    "currencyIdScale": "0x0000",
-                    "currencyIdType": "interbtc_primitives.CurrencyId",
-                    "existentialDeposit": "0",
-                    "transfersEnabled": true
-                }
-            },
-            {
-                "assetId": 10,
                 "symbol": "qkBTC",
                 "precision": 8,
                 "priceId": "bitcoin",
@@ -1852,7 +1810,7 @@
                 }
             },
             {
-                "assetId": 11,
+                "assetId": 10,
                 "symbol": "qKSM",
                 "precision": 12,
                 "priceId": "kusama",
@@ -1866,7 +1824,7 @@
                 }
             },
             {
-                "assetId": 12,
+                "assetId": 11,
                 "symbol": "qUSDT",
                 "precision": 6,
                 "priceId": "tether",


### PR DESCRIPTION
* promote LP tokens and qtokens on Interlay:
**LP iBTC-USDT
LP DOT-iBTC
LP INTR-USDT
qDOT, qUSDT, qiBTC**

<details>
  <summary> proofs </summary>

<img width="600" alt="iOS" src="https://github.com/novasamatech/nova-utils/assets/16337578/5cd19b86-0c8a-44f6-bb60-ed3490621d12">
<img width="600" alt="iOS" src="https://github.com/novasamatech/nova-utils/assets/16337578/849bc755-092a-4910-adeb-8ffcd7c051e0">
<img width="600" alt="iOS" src="https://github.com/novasamatech/nova-utils/assets/16337578/70b621fc-50d3-4bd8-8613-ad8c80f27966">

</details>

* promote qtokens on Kintsugi:
**qKSM, qUSDT, qkBTC**

<details>
  <summary> proofs </summary>

<img width="600" alt="iOS" src="https://github.com/novasamatech/nova-utils/assets/16337578/77f55b7c-4274-4ca6-b8d6-8a18122a6b95">
<img width="600" alt="iOS" src="https://github.com/novasamatech/nova-utils/assets/16337578/41cfc3f7-fdb3-46d7-9fc1-01e69af4bdf4">

</details>

* rename LP tokens
* remove unused tokens from Kintsugi dev