### PR TITLE
GitHub Actions. Single branch policy for particular changes

### DIFF
--- a/.github/workflows/update_network_list.yaml
+++ b/.github/workflows/update_network_list.yaml
@@ -73,7 +73,7 @@ jobs:
           commit-message: Update networks list
           app-id: ${{ secrets.PR_APP_ID}}
           app-token: ${{ secrets.PR_APP_TOKEN}}
-          branch-name: update-networks-${{github.run_number}}
+          branch-name: update-networks-readme
           pr-title: Update network list
           pr-body: Update networks list in https://github.com/novasamatech/nova-utils/tree/master/chains
           pr-base: master
@@ -102,7 +102,7 @@ jobs:
           commit-message: Update dapps list
           app-id: ${{ secrets.PR_APP_ID}}
           app-token: ${{ secrets.PR_APP_TOKEN}}
-          branch-name: update-dapps-${{github.run_number}}
+          branch-name: update-dapps-readme
           pr-title: Update Dapps list
           pr-body: Update dapps list in https://github.com/novasamatech/nova-utils/tree/master/dapps
           pr-base: master
@@ -130,7 +130,7 @@ jobs:
           commit-message: Update test data file
           app-id: ${{ secrets.PR_APP_ID}}
           app-token: ${{ secrets.PR_APP_TOKEN}}
-          branch-name: update-tests-${{github.run_number}}
+          branch-name: update-test-file
           pr-title: Update Test data File
           pr-body: Update test data file ./tests/chains_for_testBalance.json
           pr-base: master

--- a/.github/workflows/update_type_files.yaml
+++ b/.github/workflows/update_type_files.yaml
@@ -28,7 +28,7 @@ jobs:
           commit-message: Update chain types
           app-id: ${{ secrets.PR_APP_ID}}
           app-token: ${{ secrets.PR_APP_TOKEN}}
-          branch-name: update-types-${{github.run_number}}
+          branch-name: update-type-files
           pr-title: Update types for networks
           pr-body: This PR was generated automatically by the GitHub Action, **update-types**.
 

--- a/.github/workflows/update_xcm_data.yaml
+++ b/.github/workflows/update_xcm_data.yaml
@@ -73,7 +73,7 @@ jobs:
           app-id: ${{ secrets.PR_APP_ID}}
           app-token: ${{ secrets.PR_APP_TOKEN}}
           pr-reviewer: ${{ env.PR_REVIEWER }}
-          branch-name: update-xcm-coefficients-${{github.run_number}}
+          branch-name: update-xcm-coefficients
           pr-title: 🆙 Update XCM coefficients for ${{ env.ENVIRONMENT }} env
           pr-body: This PR was generated automatically 🤖
           pr-base: master


### PR DESCRIPTION
That changes will keep us from creating multiple PRs for the same changes, all new commits will be push to the same branch and if PR was already opened - it will updated, otherwise will be created new PR