### PR TITLE
Asset locations

### DIFF
--- a/xcm/v5/asset_locations.json
+++ b/xcm/v5/asset_locations.json
@@ -1,0 +1,32 @@
+{
+    "reserveLocations": {
+        "WND": {
+            "chainId": "e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e",
+            "multiLocation": {}
+        },
+        "WND-Westmint": {
+            "chainId": "67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9",
+            "multiLocation": {}
+        },
+        "SIRI": {
+            "chainId": "67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9",
+            "multiLocation": {
+                "parachainId": 1000,
+                "palletInstance": 50,
+                "generalIndex": 81
+            }
+        },
+        "KSM": {
+            "chainId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
+            "multiLocation": {}
+        }
+    },
+    "matchOverrides": {
+        "67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9": [
+            {
+                "assetId": 0,
+                "overrideSymbol": "WND-Westmint"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
### Things to support

1. Reuse common reserve locations to construct chain-anchored location
2. Allow to override common locations with custom ones
3. Allow multiple reserves for the same token
4. Allow cross-consensus assets (KSM on Polkadot)

### Solution

Use `reserveLocations` object to store locations relative to its consensus 

e.g. 

``` json
"WND": {
            "chainId": "e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e",
            "multiLocation": {}
        }
```

for WND token on Westend.

`multiLocation` in `reserveLocations` field SHALL NOT contain `parents` field since it is completely determined by anchoring algorithm below:


``` kotlin

class ReserveMultiLocation(val reserveChain: Chain, val multiLocation: MultiLocation)

fun ReserveMultiLocation.anchorFor(anchorChain: Chain): MultiLocation {
    // sanity checks
    if (reserveChain.parentId == null) {
        multiLocation.interior.requireParachainIdAbsent()
    } else {
        multiLocation.interior.requireParachainIdPresent()
    }

    return when {
        // Viewing from the same chain
        reserveChain.id == anchorChain.id -> multiLocation.localView()

        // Viewing relaychain from its parachain
        reserveChain.isRelay() && anchorChain.isChildOf(reserveChain) -> MultiLocation(
            // Ascend from parachain to relaychain
            parents = BigInteger.ONE,
            // reserve asset locations on relaychain tokens cannot contain ParachainId so we don't need to filter interior
            interior = multiLocation.interior
        )

        // Viewing relaychain from other relaychain
        reserveChain.isRelay() && anchorChain.isRelay() -> MultiLocation(
            // Ascend to GlobalConsensus
            parents = BigInteger.ONE,
            // Descent to Local consensus
            interior = multiLocation.interior.prependGlobalConsensus(reserveChain.id)
        )

        // Viewing relaychain from other relaychain's parachain
        reserveChain.isRelay() && anchorChain.isParachain() -> MultiLocation(
            // Ascend to Relaychain and then to GlobalConsensus
            parents = 2.toBigInteger(),
            // Descend to Local consensus
            interior = multiLocation.interior.prependGlobalConsensus(reserveChain.id)
        )

        // Viewing parachain from its relaychain
        reserveChain.isParachain() && reserveChain.isChildOf(anchorChain) -> MultiLocation(
            parents = BigInteger.ZERO,
            // Descent to ParachainId
            interior = multiLocation.interior
        )

        // Viewing parachain from parachain in the same consensus
        reserveChain.isParachain() && anchorChain.isParachain() && anchorChain.hasSameParent(reserveChain) -> MultiLocation(
            // Ascend to relaychain
            parents = BigInteger.ONE,
            // Descend to ParachainId
            interior = multiLocation.interior
        )

        // Viewing parachain from relaychain in another consensus
        reserveChain.isParachain() && anchorChain.isRelay() -> MultiLocation(
            // Ascend to GlobalConsensus
            parents = BigInteger.ONE,
            // Descend to LocalConsensus and then to ParachainId
            interior = multiLocation.interior.prependGlobalConsensus(reserveChain.parentId!!)
        )

        // Viewing parachain from parachain in another consensus
        reserveChain.isParachain() && anchorChain.isParachain() -> MultiLocation(
            // Ascend to Relaychain and then to GlobalConsensus
            parents = 2.toBigInteger(),
            // Descend to LocalConsensus and then to ParachainId
            interior = multiLocation.interior.prependGlobalConsensus(reserveChain.parentId!!)
        )


        else -> error("Logic error")
    }
}

private fun Chain.isRelay(): Boolean = parentId == null

private fun Chain.isParachain(): Boolean = parentId != null

private fun Chain.hasSameParent(other: Chain): Boolean = parentId == other.parentId

private fun Chain.isChildOf(other: Chain): Boolean = parentId == other.id

private fun MultiLocation.Interior.requireParachainIdPresent(): MultiLocation.Interior {
    require(junctionList.any { it is MultiLocation.Junction.ParachainId })

    return this
}

private fun MultiLocation.Interior.requireParachainIdAbsent(): MultiLocation.Interior {
    require(junctionList.none { it is MultiLocation.Junction.ParachainId })

    return this
}

private fun MultiLocation.Interior.prependGlobalConsensus(globalConsensus: ChainId): MultiLocation.Interior {
    val junctions = listOf(MultiLocation.Junction.GlobalConsensus(globalConsensus)) + junctionList

    return junctions.toInterior()
}

fun MultiLocation.localView(): MultiLocation {
    return MultiLocation(
        parents = BigInteger.ZERO,
        interior = interior.junctionList
            .takeLastWhile { it !is Junction.ParachainId }
            .toInterior()
    )
}

```

We use `matchOverrides` to either override symbol (`overrideSymbol`) to match against `reserveLocations` or to entirely override multilocation (`overrideMultiLocation). Those overrides are mutually-exclusive:

``` json
"matchOverrides": {
        "67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9": [
            {
                "assetId": 0,
                "overrideSymbol": "WND-Westmint"
            }
        ]
    }
```

`overrideMultiLocation` field SHALL NOT be modified (anchored e.t.c)and MAY contain `parents` field

Pushed JSON contains the following cases:

1. Shared locations for common reserves (KSM, WND)
2. Multiple reserves for the same token ("WND-Westmint")
3. Overrides for WND on Westmint to specify right reserve ("WND-Westmint")
4. KSM location can be used on Polkadot Asset Hub without any additional config changes due to anchoring algoirhtm 