### PR TITLE
fix Statescan uri

### DIFF
--- a/chains/v15/chains_dev.json
+++ b/chains/v15/chains_dev.json
@@ -375,9 +375,8 @@
         "explorers": [
             {
                 "name": "Statescan",
-                "account": "https://westmint.statescan.io/account/{address}",
-                "extrinsic": "https://westmint.statescan.io/extrinsic/{hash}",
-                "event": "https://westmint.statescan.io/event/{event}"
+                "account": "https://westmint.statescan.io/#/accounts/{address}",
+                "event": "https://westmint.statescan.io/#/events/{event}"
             }
         ],
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Westmint_Testnet.svg",
@@ -491,9 +490,8 @@
             },
             {
                 "name": "Statescan",
-                "extrinsic": "https://statemine.statescan.io/extrinsic/{hash}",
-                "account": "https://statemine.statescan.io/account/{address}",
-                "event": "https://statemine.statescan.io/event/{event}"
+                "account": "https://statemine.statescan.io/#/accounts/{address}",
+                "event": "https://statemine.statescan.io/#/events/{event}"
             },
             {
                 "name": "Sub.ID",
@@ -4496,9 +4494,8 @@
             },
             {
                 "name": "Statescan",
-                "account": "https://statemint.statescan.io/account/{address}",
-                "extrinsic": "https://statemint.statescan.io/extrinsic/{hash}",
-                "event": "https://statemint.statescan.io/event/{event}"
+                "account": "https://statemint.statescan.io/#/accounts/{address}",
+                "event": "https://statemint.statescan.io/#/events/{event}"
             },
             {
                 "name": "Polkaholic",
@@ -7334,8 +7331,7 @@
         "explorers": [
             {
                 "name": "Governance2 Testnet explorer",
-                "extrinsic": "https://gov2.statescan.io/extrinsic/{hash}",
-                "account": "https://gov2.statescan.io/account/{address}"
+                "account": "https://gov2.statescan.io/#/accounts/{address}"
             }
         ],
         "types": {

--- a/chains/v16/chains_dev.json
+++ b/chains/v16/chains_dev.json
@@ -403,9 +403,8 @@
         "explorers": [
             {
                 "name": "Statescan",
-                "account": "https://westmint.statescan.io/account/{address}",
-                "extrinsic": "https://westmint.statescan.io/extrinsic/{hash}",
-                "event": "https://westmint.statescan.io/event/{event}"
+                "account": "https://westmint.statescan.io/#/accounts/{address}",
+                "event": "https://westmint.statescan.io/#/events/{event}"
             }
         ],
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Westmint_Testnet.svg",
@@ -520,9 +519,8 @@
             },
             {
                 "name": "Statescan",
-                "extrinsic": "https://statemine.statescan.io/extrinsic/{hash}",
-                "account": "https://statemine.statescan.io/account/{address}",
-                "event": "https://statemine.statescan.io/event/{event}"
+                "account": "https://statemine.statescan.io/#/accounts/{address}",
+                "event": "https://statemine.statescan.io/#/events/{event}"
             },
             {
                 "name": "Sub.ID",
@@ -4528,9 +4526,8 @@
             },
             {
                 "name": "Statescan",
-                "account": "https://statemint.statescan.io/account/{address}",
-                "extrinsic": "https://statemint.statescan.io/extrinsic/{hash}",
-                "event": "https://statemint.statescan.io/event/{event}"
+                "account": "https://statemint.statescan.io/#/accounts/{address}",
+                "event": "https://statemint.statescan.io/#/events/{event}"
             },
             {
                 "name": "Polkaholic",
@@ -7370,8 +7367,7 @@
         "explorers": [
             {
                 "name": "Governance2 Testnet explorer",
-                "extrinsic": "https://gov2.statescan.io/extrinsic/{hash}",
-                "account": "https://gov2.statescan.io/account/{address}"
+                "account": "https://gov2.statescan.io/#/accounts/{address}"
             }
         ],
         "types": {


### PR DESCRIPTION
now we have error for Statescan [urls](https://westmint.statescan.io/account/5EAcmrE5rjfm2pxTDBZFpthxHgDR795BsVFshxyR5fCpp6uH):

![image](https://github.com/novasamatech/nova-utils/assets/16337578/ba685a84-3118-4b7c-b095-41febe59a272)

changed uri for `events` and `accounts`, removed `extrinsics` as [search](https://statemine.statescan.io/#/extrinsic/0x55b81334e0ef0dbdc1d4b00e26edeb6173ff5e7293aafcf27a0444a3c2b0ab3b) by extrinsic hash is not working