### PR TITLE
Revert "update Parallel nodes order"

### DIFF
--- a/chains/v17/chains_dev.json
+++ b/chains/v17/chains_dev.json
@@ -4307,12 +4307,12 @@
         ],
         "nodes": [
             {
-                "url": "wss://parallel-rpc.dwellir.com",
-                "name": "Dwellir node"
-            },
-            {
                 "url": "wss://rpc.parallel.fi",
                 "name": "Parallel node"
+            },
+            {
+                "url": "wss://parallel-rpc.dwellir.com",
+                "name": "Dwellir node"
             }
         ],
         "explorers": [

--- a/chains/v18/chains_dev.json
+++ b/chains/v18/chains_dev.json
@@ -4311,12 +4311,12 @@
         ],
         "nodes": [
             {
-                "url": "wss://parallel-rpc.dwellir.com",
-                "name": "Dwellir node"
-            },
-            {
                 "url": "wss://rpc.parallel.fi",
                 "name": "Parallel node"
+            },
+            {
+                "url": "wss://parallel-rpc.dwellir.com",
+                "name": "Dwellir node"
             }
         ],
         "explorers": [


### PR DESCRIPTION
This reverts commit 674cc22c430a145a6fad96990eca193bb5429744.

Dweller node is not stable:
![image](https://github.com/novasamatech/nova-utils/assets/16337578/4bcee169-beba-4727-9a96-700c15b58a84)
![image](https://github.com/novasamatech/nova-utils/assets/16337578/d0dc70e0-5467-40a0-a4dc-e48c53ff5398)
