### PR TITLE
Add RadiumBlock nodes to chains json

### DIFF
--- a/chains/v18/chains.json
+++ b/chains/v18/chains.json
@@ -279,6 +279,10 @@
                 "name": "Dotters Net node"
             },
             {
+                "url": "wss://westend.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
+            },
+            {
                 "url": "wss://westend.api.onfinality.io/public-ws",
                 "name": "OnFinality node"
             }
@@ -1564,6 +1568,10 @@
                 "name": "Blast node"
             },
             {
+                "url": "wss://moonriver.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
+            },
+            {
                 "url": "wss://moonriver-rpc.dwellir.com",
                 "name": "Dwellir node"
             }
@@ -1783,6 +1791,10 @@
             {
                 "url": "wss://shiden-rpc.dwellir.com",
                 "name": "Dwellir node"
+            },
+            {
+                "url": "wss://shiden.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
             },
             {
                 "url": "wss://shiden.api.onfinality.io/public-ws",
@@ -2649,6 +2661,10 @@
                 "name": "Dwellir node"
             },
             {
+                "url": "wss://khala.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
+            },
+            {
                 "url": "wss://khala.api.onfinality.io/public-ws",
                 "name": "OnFinality node"
             }
@@ -3446,6 +3462,10 @@
             {
                 "url": "wss://astar-rpc.dwellir.com",
                 "name": "Dwellir node"
+            },
+            {
+                "url": "wss://astar.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
             },
             {
                 "url": "wss://astar.api.onfinality.io/public-ws",
@@ -5214,6 +5234,10 @@
             {
                 "url": "wss://api.phala.network/ws",
                 "name": "Phala node"
+            },
+            {
+                "url": "wss://phala.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
             },
             {
                 "url": "wss://phala.api.onfinality.io/public-ws",

--- a/chains/v18/chains_dev.json
+++ b/chains/v18/chains_dev.json
@@ -279,6 +279,10 @@
                 "name": "Dotters Net node"
             },
             {
+                "url": "wss://westend.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
+            },
+            {
                 "url": "wss://westend.api.onfinality.io/public-ws",
                 "name": "OnFinality node"
             }
@@ -1245,6 +1249,10 @@
                 "name": "Blast node"
             },
             {
+                "url": "wss://moonriver.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
+            },
+            {
                 "url": "wss://moonriver-rpc.dwellir.com",
                 "name": "Dwellir node"
             }
@@ -1518,6 +1526,10 @@
             {
                 "url": "wss://shiden-rpc.dwellir.com",
                 "name": "Dwellir node"
+            },
+            {
+                "url": "wss://shiden.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
             },
             {
                 "url": "wss://shiden.api.onfinality.io/public-ws",
@@ -2636,6 +2648,10 @@
             {
                 "url": "wss://khala-rpc.dwellir.com",
                 "name": "Dwellir node"
+            },
+            {
+                "url": "wss://khala.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
             },
             {
                 "url": "wss://khala.api.onfinality.io/public-ws",
@@ -4080,6 +4096,10 @@
             {
                 "url": "wss://rpc.astar.network",
                 "name": "Astar node"
+            },
+            {
+                "url": "wss://astar.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
             },
             {
                 "url": "wss://astar.api.onfinality.io/public-ws",
@@ -5745,6 +5765,10 @@
             {
                 "url": "wss://api.phala.network/ws",
                 "name": "Phala node"
+            },
+            {
+                "url": "wss://phala.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
             },
             {
                 "url": "wss://phala.api.onfinality.io/public-ws",


### PR DESCRIPTION
We have added RadiumBlock endpoint nodes to chains.json and chains_dev.json in the v18 folder. Hoping these are the right files to add them.