### PR TITLE
Bifrost Pokadot. Update currency_id_scale

### DIFF
--- a/chains/v18/chains_dev.json
+++ b/chains/v18/chains_dev.json
@@ -6432,7 +6432,7 @@
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/vDOT.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x0103",
+                    "currencyIdScale": "0x0900",
                     "currencyIdType": "bifrost_primitives.currency.CurrencyId",
                     "existentialDeposit": "1000000",
                     "transfersEnabled": true
@@ -6511,7 +6511,7 @@
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/vMANTA.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x0908",
+                    "currencyIdScale": "0x0a08",
                     "currencyIdType": "bifrost_primitives.currency.CurrencyId",
                     "existentialDeposit": "10000000000000",
                     "transfersEnabled": true

--- a/chains/v18/chains_dev.json
+++ b/chains/v18/chains_dev.json
@@ -6511,7 +6511,7 @@
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/vMANTA.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x0a08",
+                    "currencyIdScale": "0x0908",
                     "currencyIdType": "bifrost_primitives.currency.CurrencyId",
                     "existentialDeposit": "10000000000000",
                     "transfersEnabled": true


### PR DESCRIPTION
Update currency id scale for Bifrost Polkadot
<details>
  <summary>vDOT</summary>

<img width="300" alt="Screenshot 2024-02-23 at 12 16 02" src="https://github.com/novasamatech/nova-utils/assets/40560660/170a2055-8c56-4180-b999-7fcaf758472e">

<img width="1300" alt="Screenshot 2024-02-23 at 12 17 27" src="https://github.com/novasamatech/nova-utils/assets/40560660/19a0d2fb-7a81-4a86-b3e0-390801e687f5">

</details>

<details>
  <summary>vMANTA</summary>

<img width="300" alt="Screenshot 2024-02-23 at 12 16 54" src="https://github.com/novasamatech/nova-utils/assets/40560660/1813ee93-5916-441b-b7a1-82f9e7883704">

<img width="1300" alt="Screenshot 2024-02-23 at 12 19 51" src="https://github.com/novasamatech/nova-utils/assets/40560660/5ad2c31e-2908-4d79-9cb9-9da5d97422bc">


</details>