### PR TITLE
promote Polkadex gov1

### DIFF
--- a/chains/v18/chains.json
+++ b/chains/v18/chains.json
@@ -5896,6 +5896,9 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Polkadex.svg",
         "addressPrefix": 88,
+        "options": [
+            "governance-v1"
+        ],
         "additional": {
             "themeColor": "#1F78FF",
             "stakingWiki": "https://docs.novawallet.io/nova-wallet-wiki/staking/polkadex-pdex-staking",


### PR DESCRIPTION
* without Gov API as not supported by Subsquare