### PR TITLE
XCM. return USDT and SUB ✅

### DIFF
--- a/xcm/v6/transfers.json
+++ b/xcm/v6/transfers.json
@@ -339,7 +339,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "800000000000"
+          "value": "8000000000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -4251,7 +4251,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "800000000000"
+                    "value": "8000000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v6/transfers.json
+++ b/xcm/v6/transfers.json
@@ -3536,7 +3536,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "803700"
+                    "value": "1005251"
                   },
                   "instructions": "xcmPalletDest"
                 }

--- a/xcm/v6/transfers.json
+++ b/xcm/v6/transfers.json
@@ -3528,6 +3528,20 @@
                 }
               },
               "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "fc41b9bd8ef8fe53d58c7ea67c794c7ec9a73daf05e6d54b14ff6342c99ba64c",
+                "assetId": 14,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "803700"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
             }
           ]
         },
@@ -4215,6 +4229,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "1000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 18,
+          "assetLocation": "SUB",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "4a12be580bb959937a1c7a61d5cf24428ed67fa571974b4007645d1886e7c89f",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "800000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v6/transfers_dev.json
+++ b/xcm/v6/transfers_dev.json
@@ -393,7 +393,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "800000000000"
+          "value": "8000000000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -7144,7 +7144,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "800000000000"
+                    "value": "8000000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v6/transfers_dev.json
+++ b/xcm/v6/transfers_dev.json
@@ -4254,7 +4254,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "803700"
+                    "value": "1005251"
                   },
                   "instructions": "xcmPalletDest"
                 }


### PR DESCRIPTION
Tested by:
- [Polkadot Asset Hub USDT -> Acala](https://acala.subscan.io/xcm_message/polkadot-b9fc98390605c66d6554325c0c6e932b2df383a8)
- [HydraDX SUB -> Subsocial](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fpara.subsocial.network#/explorer/query/0xc5bcc59a41406b14fb385d12d414b23d65174fd1532b53d224b5ddb8bb90ed36)