### PR TITLE
Add avail full types

### DIFF
--- a/chains/v18/chains_dev.json
+++ b/chains/v18/chains_dev.json
@@ -10324,7 +10324,7 @@
             }
         ],
         "types": {
-            "url": "https://raw.githubusercontent.com/novasamatech/nova-utils/fix/avail-types/chains/v2/types/avail_turing.json",
+            "url": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/chains/v2/types/avail_turing.json",
             "overridesCommon": true
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Avail_Testnet.svg",

--- a/chains/v18/chains_dev.json
+++ b/chains/v18/chains_dev.json
@@ -10324,7 +10324,7 @@
             }
         ],
         "types": {
-            "url": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/chains/v2/types/avail_turing.json",
+            "url": "https://raw.githubusercontent.com/novasamatech/nova-utils/fix/avail-types/chains/v2/types/avail_turing.json",
             "overridesCommon": true
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Avail_Testnet.svg",

--- a/chains/v2/types/avail_turing.json
+++ b/chains/v2/types/avail_turing.json
@@ -1,8 +1,15 @@
 {
   "runtime_id": 28,
   "types": {
+    "Balance": "u128",
+    "Index": "u32",
+    "Phase": "frame_system.Phase",
     "Address": "sp_runtime.multiaddress.MultiAddress",
-    "ExtrinsicSignature": "sp_runtime.MultiSignature"
+    "ExtrinsicSignature": "sp_runtime.MultiSignature",
+    "da_runtime.RuntimeEvent": "GenericEvent",
+    "da_runtime.RuntimeCall": "GenericCall",
+    "sp_core.crypto.AccountId32": "GenericAccountId",
+    "pallet_identity.types.Data": "Data"
   },
   "versioning": []
 }


### PR DESCRIPTION
iOS currently requires all the types if derivation via the file