### PR TITLE
no-tls1.2-support flags for parity kusama and polkadot nodes

### DIFF
--- a/chains/v20/chains.json
+++ b/chains/v20/chains.json
@@ -32,7 +32,8 @@
             },
             {
                 "url": "wss://apps-rpc.polkadot.io",
-                "name": "Public node"
+                "name": "Public node",
+                "features": ["noTls12"]
             },
             {
                 "url": "wss://polkadot-rpc.dwellir.com",
@@ -156,7 +157,8 @@
             },
             {
                 "url": "wss://apps-kusama-rpc.polkadot.io",
-                "name": "Public node"
+                "name": "Public node",
+                "features": ["noTls12"]
             },
             {
                 "url": "wss://kusama-rpc.dwellir.com",

--- a/chains/v20/chains_dev.json
+++ b/chains/v20/chains_dev.json
@@ -32,7 +32,8 @@
             },
             {
                 "url": "wss://apps-rpc.polkadot.io",
-                "name": "Public node"
+                "name": "Public node",
+                "features": ["noTls12"]
             },
             {
                 "url": "wss://polkadot-rpc.dwellir.com",
@@ -156,7 +157,8 @@
             },
             {
                 "url": "wss://apps-kusama-rpc.polkadot.io",
-                "name": "Public node"
+                "name": "Public node",
+                "features": ["noTls12"]
             },
             {
                 "url": "wss://kusama-rpc.dwellir.com",


### PR DESCRIPTION
Fix until the iOS project adds support for TLS version 1.3.