### PR TITLE
promote WETH, WBTC-Snowbridge on polkadot asset hub, hydration

### DIFF
--- a/chains/v20/chains.json
+++ b/chains/v20/chains.json
@@ -3852,6 +3852,28 @@
                 "typeExtras": {
                     "assetId": "31337"
                 }
+            },
+            {
+                "assetId": 9,
+                "symbol": "WETH-Snowbridge",
+                "precision": 18,
+                "type": "statemine",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/WETH-Snowbridge.svg",
+                "typeExtras": {
+                    "assetId": "0x02020907040300c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                    "palletName": "ForeignAssets"
+                }
+            },
+            {
+                "assetId": 10,
+                "symbol": "WBTC-Snowbridge",
+                "precision": 8,
+                "type": "statemine",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/WBTC-Snowbridge.svg",
+                "typeExtras": {
+                    "assetId": "0x020209070403002260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                    "palletName": "ForeignAssets"
+                }
             }
         ],
         "nodes": [
@@ -4648,7 +4670,7 @@
                 "precision": 18,
                 "priceId": "ethereum-wormhole",
                 "type": "orml",
-                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/WETH-worm.svg",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/WETH-Acala.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x04000000",
                     "currencyIdType": "u32",
@@ -4662,7 +4684,7 @@
                 "precision": 8,
                 "priceId": "wrapped-bitcoin",
                 "type": "orml",
-                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/WBTC.svg",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/WBTC-Acala.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x03000000",
                     "currencyIdType": "u32",
@@ -5077,6 +5099,32 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/WUD.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x95420f00",
+                    "currencyIdType": "u32",
+                    "existentialDeposit": "1",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 37,
+                "symbol": "WETH-Snowbridge",
+                "precision": 18,
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/WETH-Snowbridge.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x06430f00",
+                    "currencyIdType": "u32",
+                    "existentialDeposit": "1",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 38,
+                "symbol": "WBTC-Snowbridge",
+                "precision": 8,
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/WBTC-Snowbridge.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0xfe420f00",
                     "currencyIdType": "u32",
                     "existentialDeposit": "1",
                     "transfersEnabled": true


### PR DESCRIPTION
<details>
  <summary> WETH-Snowbridge, WBTC-Snowbridge on Polkadot Asset Hub </summary>

<img width="300" alt="Screenshot" src="https://github.com/novasamatech/nova-utils/assets/16337578/2399cfeb-89f9-4d97-9572-4638d6e00aa5">
<img width="300" alt="Screenshot" src="https://github.com/novasamatech/nova-utils/assets/16337578/e67e123e-631c-49fd-85b8-faf0817fa5c8">
<img width="300" alt="Screenshot" src="https://github.com/novasamatech/nova-utils/assets/16337578/714e8375-f2ed-4787-b4bc-cc7b734e92a0">

</details>
<details>
  <summary> WETH-Snowbridge, WBTC-Snowbridge on Hydration </summary>

<img width="300" alt="Screenshot" src="https://github.com/novasamatech/nova-utils/assets/16337578/91a780d2-afd9-426e-b026-f6c6a0c1ec9b">
<img width="300" alt="Screenshot" src="https://github.com/novasamatech/nova-utils/assets/16337578/b91e6b75-10a9-4632-9db1-2126acd13c8a">

</details>

* fixed icons for -Acala tokens