### PR TITLE
fix: adding dwellir node for subsocial

### DIFF
--- a/chains/v20/chains.json
+++ b/chains/v20/chains.json
@@ -4558,6 +4558,10 @@
         ],
         "nodes": [
             {
+                "url": "wss://subsocial-rpc.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
                 "url": "wss://para.f3joule.space",
                 "name": "Subsocial node"
             },

--- a/chains/v20/chains_dev.json
+++ b/chains/v20/chains_dev.json
@@ -4958,6 +4958,10 @@
         ],
         "nodes": [
             {
+                "url": "wss://subsocial-rpc.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
                 "url": "wss://para.f3joule.space",
                 "name": "Subsocial node"
             },


### PR DESCRIPTION
<img width="1173" alt="Screenshot 2024-08-13 at 09 43 08" src="https://github.com/user-attachments/assets/95a42d6a-c67f-4e79-83d9-3adb026cd8dd">


that available via dwellir:
https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fsubsocial-rpc.dwellir.com#/explorer