### PR TITLE
fix: move Manta collator to excluded as not generating rewards

### DIFF
--- a/staking/validators/v1/nova_validators.json
+++ b/staking/validators/v1/nova_validators.json
@@ -33,6 +33,10 @@
         "b91746b45e0346cc2f815a520b9c6cb4d5c0902af848db0a80f85932d2e8276a":
         [
             "5FjdibsxmNFas5HWcT2i1AXbpfgiNfWqezzo88H2tskxWdt2"
+        ],
+        "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb":
+        [
+            "dfZYPuCevYRLyH3nPSNcZJb8LPuYaSby16PgWA2eE64kUvV6A"
         ]
     }
 }

--- a/staking/validators/v1/nova_validators_dev.json
+++ b/staking/validators/v1/nova_validators_dev.json
@@ -39,6 +39,10 @@
             "5FZoQhgUCmqBxnkHX7jCqThScS2xQWiwiF61msg63CFL3Y8f",
             "5CFPcUJgYgWryPaV1aYjSbTpbTLu42V32Ytw1L9rfoMAsfGh",
             "5CFPqoTU7fiUp1JJNbfcY2z6yavEBKDPQGg4SGeG3Fm7vCsg"
+        ],
+      "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb":
+        [
+            "dfZYPuCevYRLyH3nPSNcZJb8LPuYaSby16PgWA2eE64kUvV6A"
         ]
     }
 }


### PR DESCRIPTION
collator has been excluded due to having high APR therefore being recommended first by Nova but not generating rewards long time resulted in users complains:

![photo_2024-09-16 15 08 21](https://github.com/user-attachments/assets/a532888f-3349-46ac-937d-49970e0e4109)
