### PR TITLE
fix: update Avail nodes

### DIFF
--- a/chains/v20/chains.json
+++ b/chains/v20/chains.json
@@ -8790,8 +8790,8 @@
         ],
         "nodes": [
             {
-                "url": "wss://zeref-api.slowops.xyz/ws",
-                "name": "Turing node"
+                "url": "wss://avail-rpc.rubynodes.io/",
+                "name": "RubyNode node"
             },
             {
                 "url": "wss://avail-mainnet.public.blastapi.io/",

--- a/chains/v20/chains.json
+++ b/chains/v20/chains.json
@@ -8790,16 +8790,28 @@
         ],
         "nodes": [
             {
+                "url": "wss://avail-mainnet.public.blastapi.io/",
+                "name": "Bware node"
+            },
+            {
                 "url": "wss://avail-rpc.rubynodes.io/",
                 "name": "RubyNode node"
             },
             {
-                "url": "wss://avail-mainnet.public.blastapi.io/",
-                "name": "Blastapi node"
+                "url": "wss://avail-us.brightlystake.com",
+                "name": "BrightlyStake node"
+            },
+            {
+                "url": "wss://rpc-avail.globalstake.io",
+                "name": "GlobalStake node"
             },
             {
                 "url": "wss://avail.rpc.bountyblok.io",
                 "name": "Bountyblok node"
+            },
+            {
+                "url": "wss://avail.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
             }
         ],
         "explorers": [

--- a/chains/v20/chains_dev.json
+++ b/chains/v20/chains_dev.json
@@ -10922,16 +10922,28 @@
         ],
         "nodes": [
             {
+                "url": "wss://avail-mainnet.public.blastapi.io/",
+                "name": "Bware node"
+            },
+            {
                 "url": "wss://avail-rpc.rubynodes.io/",
                 "name": "RubyNode node"
             },
             {
-                "url": "wss://avail-mainnet.public.blastapi.io/",
-                "name": "Blastapi node"
+                "url": "wss://avail-us.brightlystake.com",
+                "name": "BrightlyStake node"
+            },
+            {
+                "url": "wss://rpc-avail.globalstake.io",
+                "name": "GlobalStake node"
             },
             {
                 "url": "wss://avail.rpc.bountyblok.io",
                 "name": "Bountyblok node"
+            },
+            {
+                "url": "wss://avail.public.curie.radiumblock.co/ws",
+                "name": "RadiumBlock node"
             }
         ],
         "explorers": [

--- a/chains/v20/chains_dev.json
+++ b/chains/v20/chains_dev.json
@@ -10922,8 +10922,8 @@
         ],
         "nodes": [
             {
-                "url": "wss://zeref-api.slowops.xyz/ws",
-                "name": "Turing node"
+                "url": "wss://avail-rpc.rubynodes.io/",
+                "name": "RubyNode node"
             },
             {
                 "url": "wss://avail-mainnet.public.blastapi.io/",


### PR DESCRIPTION
can not connect to `wss://mainnet.avail-rpc.com/` from https://docs.availproject.org/docs/networks#alternate-endpoints

![image](https://github.com/user-attachments/assets/fb42b6ea-11a2-43dd-ad26-5bc471c5e421)

so selected `RubyNode` as substitutor