### PR TITLE
promote Pendulum assets, fix EURC (Mykobo) icons on Amplitude

### DIFF
--- a/chains/v20/chains.json
+++ b/chains/v20/chains.json
@@ -6756,7 +6756,7 @@
                 "symbol": "EURC.s",
                 "precision": 12,
                 "type": "orml",
-                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/EUR.svg",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/EURM.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x0201455552432112ee863867e4e219fe254c0918b00bc9ea400775bfc3ab4430971ce505877c",
                     "currencyIdType": "spacewalk_primitives.CurrencyId",
@@ -7137,7 +7137,7 @@
                 "symbol": "EURC.s",
                 "precision": 12,
                 "type": "orml",
-                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/EUR.svg",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/EURM.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x0201455552432112ee863867e4e219fe254c0918b00bc9ea400775bfc3ab4430971ce505877c",
                     "currencyIdType": "spacewalk_primitives.CurrencyId",
@@ -7194,6 +7194,76 @@
                 "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/HDX.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x0108",
+                    "currencyIdType": "spacewalk_primitives.CurrencyId",
+                    "existentialDeposit": "1000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 14,
+                "symbol": "ASTR",
+                "precision": 18,
+                "type": "orml",
+                "priceId": "astar",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/white/Astar.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0109",
+                    "currencyIdType": "spacewalk_primitives.CurrencyId",
+                    "existentialDeposit": "1000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 15,
+                "symbol": "vDOT",
+                "precision": 10,
+                "type": "orml",
+                "priceId": "voucher-dot",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/vDOT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x010a",
+                    "currencyIdType": "spacewalk_primitives.CurrencyId",
+                    "existentialDeposit": "1000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 16,
+                "symbol": "BNC",
+                "precision": 12,
+                "type": "orml",
+                "priceId": "bifrost-native-coin",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/white/Bifrost.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x010b",
+                    "currencyIdType": "spacewalk_primitives.CurrencyId",
+                    "existentialDeposit": "10000000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 17,
+                "symbol": "USDC.axl",
+                "precision": 6,
+                "type": "orml",
+                "priceId": "axlusdc",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/USDCaxl.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x010c",
+                    "currencyIdType": "spacewalk_primitives.CurrencyId",
+                    "existentialDeposit": "1000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 18,
+                "symbol": "EURC.s",
+                "precision": 12,
+                "type": "orml",
+                "priceId": "euro-coin",
+                "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/tokens/white/EURC.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x020145555243cf4f5a26e2090bb3adcf02c7a9d73dbfe6659cc690461475b86437fa49c71136",
                     "currencyIdType": "spacewalk_primitives.CurrencyId",
                     "existentialDeposit": "1000",
                     "transfersEnabled": true

--- a/chains/v21/chains.json
+++ b/chains/v21/chains.json
@@ -6762,7 +6762,7 @@
                 "symbol": "EURC.s",
                 "precision": 12,
                 "type": "orml",
-                "icon": "EURC.svg",
+                "icon": "EURM.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x0201455552432112ee863867e4e219fe254c0918b00bc9ea400775bfc3ab4430971ce505877c",
                     "currencyIdType": "spacewalk_primitives.CurrencyId",
@@ -7143,7 +7143,8 @@
                 "symbol": "EURC.s",
                 "precision": 12,
                 "type": "orml",
-                "icon": "EURC.svg",
+                "icon": "EURM.svg",
+                "priceId": "euro-coin",
                 "typeExtras": {
                     "currencyIdScale": "0x0201455552432112ee863867e4e219fe254c0918b00bc9ea400775bfc3ab4430971ce505877c",
                     "currencyIdType": "spacewalk_primitives.CurrencyId",
@@ -7200,6 +7201,76 @@
                 "icon": "HDX.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x0108",
+                    "currencyIdType": "spacewalk_primitives.CurrencyId",
+                    "existentialDeposit": "1000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 14,
+                "symbol": "ASTR",
+                "precision": 18,
+                "type": "orml",
+                "priceId": "astar",
+                "icon": "ASTR.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0109",
+                    "currencyIdType": "spacewalk_primitives.CurrencyId",
+                    "existentialDeposit": "1000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 15,
+                "symbol": "vDOT",
+                "precision": 10,
+                "type": "orml",
+                "priceId": "voucher-dot",
+                "icon": "vDOT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x010a",
+                    "currencyIdType": "spacewalk_primitives.CurrencyId",
+                    "existentialDeposit": "1000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 16,
+                "symbol": "BNC",
+                "precision": 12,
+                "type": "orml",
+                "priceId": "bifrost-native-coin",
+                "icon": "BNC.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x010b",
+                    "currencyIdType": "spacewalk_primitives.CurrencyId",
+                    "existentialDeposit": "10000000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 17,
+                "symbol": "USDC.axl",
+                "precision": 6,
+                "type": "orml",
+                "priceId": "axlusdc",
+                "icon": "USDCaxl.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x010c",
+                    "currencyIdType": "spacewalk_primitives.CurrencyId",
+                    "existentialDeposit": "1000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 18,
+                "symbol": "EURC.s",
+                "precision": 12,
+                "type": "orml",
+                "priceId": "euro-coin",
+                "icon": "EURC.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x020145555243cf4f5a26e2090bb3adcf02c7a9d73dbfe6659cc690461475b86437fa49c71136",
                     "currencyIdType": "spacewalk_primitives.CurrencyId",
                     "existentialDeposit": "1000",
                     "transfersEnabled": true

--- a/chains/v21/chains_dev.json
+++ b/chains/v21/chains_dev.json
@@ -7739,7 +7739,7 @@
                 "symbol": "EURC.s",
                 "precision": 12,
                 "type": "orml",
-                "icon": "EURC.svg",
+                "icon": "EURM.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x0201455552432112ee863867e4e219fe254c0918b00bc9ea400775bfc3ab4430971ce505877c",
                     "currencyIdType": "spacewalk_primitives.CurrencyId",


### PR DESCRIPTION
- promotes tokens added on Pendulum here: https://github.com/novasamatech/nova-utils/pull/3168

<details>
  <summary>  Pendulum: ASTR, vDOT, BNC, USDC.axl, EURC.s ✅ 
 balances and fee </summary>

<img width="300" alt="Screenshot" src="https://github.com/user-attachments/assets/13606094-7447-4593-b74f-0ae6a10940ec">
<img width="300" alt="Screenshot" src="https://github.com/user-attachments/assets/f856faaa-518b-4d40-a470-e13a6e4594d9">
<img width="300" alt="Screenshot" src="https://github.com/user-attachments/assets/e9b6a9a8-2f0d-4dd4-bd41-44e6e1f59a63">
<img width="300" alt="Screenshot" src="https://github.com/user-attachments/assets/beaabb51-964f-44e4-965a-01c8fee9ec59">
<img width="300" alt="Screenshot" src="https://github.com/user-attachments/assets/43147efb-5d14-4cdc-8988-578fc37f5af0">
<img width="300" alt="Screenshot" src="https://github.com/user-attachments/assets/c050bf26-77ca-480f-9879-09d45099de36">

</details>

- fix deprecating EURC.s (Mykobo) token icon