### PR TITLE
fix: change subquery urls

### DIFF
--- a/chains/v21/chains.json
+++ b/chains/v21/chains.json
@@ -217,13 +217,13 @@
             "staking": [
                 {
                     "type": "subquery",
-                    "url": "https://gateway.subquery.network/query/0x1b"
+                    "url": "https://subquery-history-kusama-prod.novasama-tech.org"
                 }
             ],
             "history": [
                 {
                     "type": "subquery",
-                    "url": "https://gateway.subquery.network/query/0x1b"
+                    "url": "https://subquery-history-kusama-prod.novasama-tech.org"
                 }
             ],
             "crowdloans": [

--- a/chains/v21/chains_dev.json
+++ b/chains/v21/chains_dev.json
@@ -217,13 +217,13 @@
             "staking": [
                 {
                     "type": "subquery",
-                    "url": "https://gateway.subquery.network/query/0x1b"
+                    "url": "https://subquery-history-kusama-prod.novasama-tech.org"
                 }
             ],
             "history": [
                 {
                     "type": "subquery",
-                    "url": "https://gateway.subquery.network/query/0x1b"
+                    "url": "https://subquery-history-kusama-prod.novasama-tech.org"
                 }
             ],
             "crowdloans": [


### PR DESCRIPTION
Due to error in subquery history project:
```bash
curl 'https://gateway.subquery.network/query/0x1b' \
-X POST \
-H 'Host: gateway.subquery.network' \
-H 'Connection: Keep-Alive' \
-H 'User-Agent: okhttp/4.11.0' \
-H 'Content-Type: application/json; charset=UTF-8' \
--data-raw '{"query":"query {\n    eraValidatorInfos(\n        filter:{\n            era:{ greaterThanOrEqualTo: 7299, lessThanOrEqualTo: 7382},\n            address: { equalTo: \"DhK6qU2U5kDWeJKvPRtmnWRs8ETUGZ9S9QmNmQFuzrNoKm4\" }\n        }\n    ) {\n        nodes {\n            id\n            address\n            era\n            total\n            own\n        }\n    }\n}"}'
```

lets switch to our infra

```bash
curl --location 'https://subquery-history-kusama-prod.novasama-tech.org' \
--header 'Connection: Keep-Alive' \
--header 'User-Agent: okhttp/4.11.0' \
--header 'Content-Type: application/json; charset=UTF-8' \
--data '{"query":"query {\n    eraValidatorInfos(\n        filter:{\n            era:{ greaterThanOrEqualTo: 7299, lessThanOrEqualTo: 7382},\n            address: { equalTo: \"DhK6qU2U5kDWeJKvPRtmnWRs8ETUGZ9S9QmNmQFuzrNoKm4\" }\n        }\n    ) {\n        nodes {\n            id\n            address\n            era\n            total\n            own\n        }\n    }\n}"}'
```