### PR TITLE
feat: change eth node order

### DIFF
--- a/chains/v21/chains.json
+++ b/chains/v21/chains.json
@@ -1286,7 +1286,7 @@
                 }
             }
         ],
-        "nodeSelectionStrategy": "uniform",
+        "nodeSelectionStrategy": "roundRobin",
         "nodes": [
             {
                 "url": "https://rpc.ankr.com/eth",
@@ -1301,6 +1301,14 @@
                 "name": "Infura node 5"
             },
             {
+                "url": "wss://mainnet.infura.io/ws/v3/5717b02168b5434ba23801e1ea755afb",
+                "name": "Infura node 7"
+            },
+            {
+                "url": "wss://mainnet.infura.io/ws/v3/25bd0a6e359240529b237e5dd8b19e1f",
+                "name": "Infura node 3"
+            },
+            {
                 "url": "wss://mainnet.infura.io/ws/v3/{INFURA_API_KEY}",
                 "name": "Infura node"
             },
@@ -1309,20 +1317,12 @@
                 "name": "Infura node 2"
             },
             {
-                "url": "wss://mainnet.infura.io/ws/v3/25bd0a6e359240529b237e5dd8b19e1f",
-                "name": "Infura node 3"
-            },
-            {
                 "url": "wss://mainnet.infura.io/ws/v3/9dddd77ac74043dc9a8dc48f82822c7d",
                 "name": "Infura node 4"
             },
             {
                 "url": "wss://mainnet.infura.io/ws/v3/82fd5b2925e341719f10b7ed4376a646",
                 "name": "Infura node 6"
-            },
-            {
-                "url": "wss://mainnet.infura.io/ws/v3/5717b02168b5434ba23801e1ea755afb",
-                "name": "Infura node 7"
             }
         ],
         "explorers": [

--- a/chains/v21/chains.json
+++ b/chains/v21/chains.json
@@ -1301,14 +1301,6 @@
                 "name": "Infura node 5"
             },
             {
-                "url": "wss://mainnet.infura.io/ws/v3/5717b02168b5434ba23801e1ea755afb",
-                "name": "Infura node 7"
-            },
-            {
-                "url": "wss://mainnet.infura.io/ws/v3/25bd0a6e359240529b237e5dd8b19e1f",
-                "name": "Infura node 3"
-            },
-            {
                 "url": "wss://mainnet.infura.io/ws/v3/{INFURA_API_KEY}",
                 "name": "Infura node"
             },

--- a/chains/v21/chains_dev.json
+++ b/chains/v21/chains_dev.json
@@ -3849,16 +3849,12 @@
                 "name": "One rpc node"
             },
             {
-                "url": "wss://mainnet.infura.io/ws/v3/1e69544301064ef19edb194a14fb75f3",
-                "name": "Infura node 2"
-            },
-            {
                 "url": "wss://mainnet.infura.io/ws/v3/25bd0a6e359240529b237e5dd8b19e1f",
                 "name": "Infura node 3"
             },
             {
-                "url": "wss://mainnet.infura.io/ws/v3/32a2be59297444c9bcb2b61bb700c6fe",
-                "name": "Infura node 4"
+                "url": "wss://mainnet.infura.io/ws/v3/1e69544301064ef19edb194a14fb75f3",
+                "name": "Infura node 2"
             },
             {
                 "url": "wss://mainnet.infura.io/ws/v3/{INFURA_API_KEY}",


### PR DESCRIPTION
That PR changes order for Ethereum wss nodes:
- up that one which is good
- different env uses different keys