### PR TITLE
fix: remove Proof of chaos from refdetails

### DIFF
--- a/governance/v2/dapps.json
+++ b/governance/v2/dapps.json
@@ -34,12 +34,6 @@
         "urlV2": "https://kusama.subsquare.io/referenda/referendum/{referendumId}",
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/color/SubSquare.svg",
         "details": "Comment and react"
-      },
-      {
-        "title": "Proof of Chaos",
-        "urlV2": "https://www.proofofchaos.app/referenda/{referendumId}",
-        "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/color/Proof_of_Chaos.png",
-        "details": "Vote for NFT"
       }
     ]
   },

--- a/governance/v2/dapps_dev.json
+++ b/governance/v2/dapps_dev.json
@@ -51,12 +51,6 @@
         "urlV2": "https://kusama.subsquare.io/referenda/referendum/{referendumId}",
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/color/SubSquare.svg",
         "details": "Comment and react"
-      },
-      {
-        "title": "Proof of Chaos",
-        "urlV2": "https://www.proofofchaos.app/referenda/{referendumId}",
-        "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/color/Proof_of_Chaos.png",
-        "details": "Vote for NFT"
       }
     ]
   },


### PR DESCRIPTION
doesn't supports our url builder model atm:
was:
https://www.proofofchaos.app/referenda/{referendumId}
now:
https://www.proofofchaos.app/kusama/vote

![image](https://github.com/user-attachments/assets/5fee4b26-4a44-49ba-b73b-1ecda48e4919)
