### PR TITLE
Change PolkaIdentity URL

### DIFF
--- a/dapps/README.md
+++ b/dapps/README.md
@@ -45,7 +45,7 @@
 |  41 | Parallel Finance App                 | https://app-polkadot.parallel.fi                    | utilities             |
 |  42 | Pendulum Chain Portal                | https://portal.pendulumchain.org/pendulum/dashboard | utilities,staking     |
 |  43 | Phala App                            | https://app.phala.network/                          | staking               |
-|  44 | PolkaIdentity                        | https://polkaidentity.com                           | social,utilities      |
+|  44 | PolkaIdentity                        | https://app.polkaidentity.com                       | social,utilities      |
 |  45 | Polkadex Orderbook                   | https://orderbook.polkadex.trade/                   | dex,utilities         |
 |  46 | Polkadot Staking Dashboard           | https://staking.polkadot.cloud/#/overview           | staking,utilities     |
 |  47 | Polkadot.js                          | https://polkadot.js.org/apps/                       | utilities             |

--- a/dapps/dapps.json
+++ b/dapps/dapps.json
@@ -639,7 +639,7 @@
     {
       "name": "PolkaIdentity",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/PolkaIdentity.svg",
-      "url": "https://polkaidentity.com",
+      "url": "https://app.polkaidentity.com",
       "categories": [
         "social",
         "utilities"

--- a/dapps/dapps_dev.json
+++ b/dapps/dapps_dev.json
@@ -705,7 +705,7 @@
     {
       "name": "PolkaIdentity",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/PolkaIdentity.svg",
-      "url": "https://polkaidentity.com",
+      "url": "https://app.polkaidentity.com",
       "categories": [
         "social",
         "utilities"

--- a/dapps/dapps_full.json
+++ b/dapps/dapps_full.json
@@ -639,7 +639,7 @@
     {
       "name": "PolkaIdentity",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/PolkaIdentity.svg",
-      "url": "https://polkaidentity.com",
+      "url": "https://app.polkaidentity.com",
       "categories": [
         "social",
         "utilities"


### PR DESCRIPTION
We have developed a landing page for PolkaIdentity and have changed the application URL, we are changing here so Nova users don't need to go through the webpage.