### PR TITLE
fix: remove identity chain id for Westend

### DIFF
--- a/chains/v21/chains.json
+++ b/chains/v21/chains.json
@@ -357,7 +357,6 @@
             "stakingWiki": "https://docs.novawallet.io/nova-wallet-wiki/staking/polkadot-and-kusama",
             "stakingMaxElectingVoters": 22500,
             "feeViaRuntimeCall": true,
-            "identityChain": "1eb6fb0ba5187434de017a70cb84d4f47142df1d571d0ef9e7e1407f2b80b93c",
             "supportsGenericLedgerApp": true
         }
     },


### PR DESCRIPTION
fix to address [iOS. Fee not loading for Westend direct start staking](https://app.clickup.com/t/8697n3u0x) issue on prod 

- also checked that has no effect on Android

<img width="300" alt="Screenshot" src="https://github.com/user-attachments/assets/b778a092-2b1b-46af-a614-0df0b5bdc202">
