### PR TITLE
promote Heima, HEI rebranding

### DIFF
--- a/chains/v21/chains.json
+++ b/chains/v21/chains.json
@@ -6712,8 +6712,8 @@
                 "assetId": 0,
                 "symbol": "HEI",
                 "precision": 18,
-                "icon": "LIT.svg",
-                "priceId": "litentry"
+                "icon": "HEI.svg",
+                "priceId": "heima"
             }
         ],
         "nodes": [
@@ -6742,7 +6742,7 @@
                 }
             ]
         },
-        "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Litentry.svg",
+        "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Heima.svg",
         "addressPrefix": 31
     },
     {

--- a/chains/v21/chains_dev.json
+++ b/chains/v21/chains_dev.json
@@ -7243,7 +7243,7 @@
                 "symbol": "HEI",
                 "precision": 18,
                 "icon": "HEI.svg",
-                "priceId": "litentry"
+                "priceId": "heima"
             }
         ],
         "nodes": [


### PR DESCRIPTION
* also changed  price from coingecko [LIT](https://www.coingecko.com/en/coins/litentry) -> [HEI](https://www.coingecko.com/en/coins/heima)

> [!NOTE]  
> didn't changed xcLIT on Moonbeam as its still displayed as is:
![image](https://github.com/user-attachments/assets/b42da5d5-3ff8-4420-b303-17f8e8367e1e)
