### PR TITLE
fix: remove governance from Westend

### DIFF
--- a/chains/v21/chains.json
+++ b/chains/v21/chains.json
@@ -349,7 +349,6 @@
         "options": [
             "testnet",
             "crowdloans",
-            "governance",
             "proxy"
         ],
         "additional": {


### PR DESCRIPTION
due to changes after Westend runtime update, we have issues on loading governance data:
https://github.com/paritytech/polkadot-sdk/pull/2072
 
could be reverted after merging this:
https://github.com/paritytech/polkadot-sdk/pull/7671
