### PR TITLE
add legacyaddressprefix flag to Bifrost Polkadot and Hyperbridge Nexus

### DIFF
--- a/chains/v21/chains.json
+++ b/chains/v21/chains.json
@@ -9065,7 +9065,8 @@
             ]
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Hyperbridge.svg",
-        "addressPrefix": 0
+        "addressPrefix": 0,
+        "legacyAddressPrefix": 42
     },
     {
         "chainId": "81443836a9a24caaa23f1241897d1235717535711d1d3fe24eae4fdc942c092c",

--- a/chains/v21/chains.json
+++ b/chains/v21/chains.json
@@ -6598,6 +6598,7 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Bifrost_Polkadot.svg",
         "addressPrefix": 0,
+        "legacyAddressPrefix": 6,
         "options": [
             "governance-v1"
         ],

--- a/chains/v21/chains_dev.json
+++ b/chains/v21/chains_dev.json
@@ -11128,6 +11128,7 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Hyperbridge.svg",
         "addressPrefix": 0,
+        "legacyAddressPrefix": 42,
         "additional": {
             "supportsGenericLedgerApp": true
         }

--- a/chains/v21/chains_dev.json
+++ b/chains/v21/chains_dev.json
@@ -7158,6 +7158,7 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Bifrost_Polkadot.svg",
         "addressPrefix": 0,
+        "legacyAddressPrefix": 6,
         "options": [
             "governance-v1"
         ],


### PR DESCRIPTION
addressprifix was updated with this [PR](https://github.com/novasamatech/nova-utils/pull/3530)
![image](https://github.com/user-attachments/assets/cfac98ef-609d-4422-a11f-661998b296a0)
