### PR TITLE
Feature/xcm execute status

### DIFF
--- a/scripts/utils/chain_model.py
+++ b/scripts/utils/chain_model.py
@@ -124,7 +124,8 @@ class Chain:
 
     @staticmethod
     def _is_connection_broken_error(e: Exception) -> bool:
-        return str(e) == "Expecting value: line 1 column 1 (char 0)"
+        message = str(e)
+        return message in {"Expecting value: line 1 column 1 (char 0)", "Failure Connection to remote host was lost."}
 
 
 class ChainAsset:

--- a/scripts/utils/chain_model.py
+++ b/scripts/utils/chain_model.py
@@ -102,10 +102,13 @@ class Chain:
         try:
             return action(self.substrate)
         except Exception as e:
-            print("Attempting to re-create connection after receiving error", e)
-            # try re-connecting socket and performing action once again
-            self.recreate_connection()
-            return action(self.substrate)
+            if self._is_connection_broken_error(e):
+                print("Attempting to re-create connection after broken connection", e)
+                # try re-connecting socket and performing action once again
+                self.recreate_connection()
+                return action(self.substrate)
+            else:
+                raise e
 
     def encodable_address(self, account_id: str):
         if self.has_evm_addresses():
@@ -118,6 +121,10 @@ class Chain:
     def _uses_multi_address(self) -> bool:
         type_def = self.substrate.get_type_definition("Address")
         return type_def is dict
+
+    @staticmethod
+    def _is_connection_broken_error(e: Exception) -> bool:
+        return str(e) == "Expecting value: line 1 column 1 (char 0)"
 
 
 class ChainAsset:

--- a/scripts/xcm_transfers/dry_run_sample.py
+++ b/scripts/xcm_transfers/dry_run_sample.py
@@ -7,10 +7,10 @@ from scripts.xcm_transfers.xcm.xcm_transfer_direction import XcmTransferDirectio
 config_files = get_xcm_config_files()
 registry = build_xcm_registry(config_files)
 
-origin_chain_name = "Polimec"
-destination_chain_name = "Polkadot"
-origin_token = "DOT"
-destination_token = "DOT"
+origin_chain_name = "Bifrost Kusama"
+destination_chain_name = "Kusama"
+origin_token = "KSM"
+destination_token = "KSM"
 
 origin_chain = registry.get_chain_by_name(origin_chain_name)
 destination_chain = registry.get_chain_by_name(destination_chain_name)
@@ -23,3 +23,4 @@ enable_debug_log()
 
 runner = TransferDryRunner(registry)
 runner.dry_run_transfer(direction)
+print(direction)

--- a/scripts/xcm_transfers/find_working_directions.py
+++ b/scripts/xcm_transfers/find_working_directions.py
@@ -53,6 +53,9 @@ def save_config():
                 if working_direction.dry_run_result.paid_delivery_fee:
                     destination_config["hasDeliveryFee"] = True
 
+                if working_direction.dry_run_result.supports_xcm_execute:
+                    destination_config["supportsXcmExecute"] = True
+
                 asset_transfers.append(destination_config)
 
             asset_config = {

--- a/scripts/xcm_transfers/utils/weight.py
+++ b/scripts/xcm_transfers/utils/weight.py
@@ -25,4 +25,3 @@ class Weight:
     @staticmethod
     def zero() -> Weight:
         return Weight(0, 0)
-

--- a/scripts/xcm_transfers/utils/weight.py
+++ b/scripts/xcm_transfers/utils/weight.py
@@ -1,14 +1,28 @@
+from __future__ import annotations
+
 class Weight:
     ref_time: int
     proof_size: int
 
-    def __init__(self, data):
-        self.ref_time = data["ref_time"]
-        self.proof_size = data["proof_size"]
+    def __init__(self, ref_time: int, proof_size: int):
+        self.ref_time = ref_time
+        self.proof_size = proof_size
 
     def is_max_by_any_dimension(self) -> bool:
         return self.ref_time >= self.max_dimension() or self.proof_size >= self.max_dimension()
 
+    def to_sdk_value(self) -> dict:
+        return {"ref_time": self.ref_time, "proof_size": self.proof_size}
+
     @staticmethod
-    def max_dimension():
+    def max_dimension() -> int:
         return 18_446_744_073_709_551_615
+
+    @staticmethod
+    def from_sdk_value(sdk_value: dict) -> Weight:
+        return Weight(sdk_value["ref_time"], sdk_value["proof_size"])
+
+    @staticmethod
+    def zero() -> Weight:
+        return Weight(0, 0)
+

--- a/scripts/xcm_transfers/xcm/call_payment/call_payment_api.py
+++ b/scripts/xcm_transfers/xcm/call_payment/call_payment_api.py
@@ -7,7 +7,7 @@ from scripts.xcm_transfers.xcm.registry.xcm_chain import XcmChain
 
 def calculate_call_weight(call: GenericCall, chain: XcmChain) -> Weight:
     call_info = chain.chain.access_substrate(lambda s: _query_call_info(call, s))
-    return Weight(call_info["weight"])
+    return Weight.from_sdk_value(call_info["weight"])
 
 def _query_call_info(call: GenericCall, substrate: SubstrateInterface):
     call_length = substrate.encode_scale("GenericCall", call).length

--- a/scripts/xcm_transfers/xcm/dry_run/dry_run_api.py
+++ b/scripts/xcm_transfers/xcm/dry_run/dry_run_api.py
@@ -53,6 +53,21 @@ class CallDryRunResult:
     forwarded_xcm: VerionsedXcm
     paid_delivery_fee: bool
 
+def dry_run_call(
+        chain: XcmChain,
+        call: GenericCall,
+        result_xcms_version: int,
+        origin: dict
+) -> dict:
+    return chain.access_substrate(
+        lambda substrate: substrate.runtime_call(api="DryRunApi", method="dry_run_call",
+                                                 params={
+                                                     "origin_caller": origin,
+                                                     "call": call,
+                                                     "result_xcms_version": result_xcms_version
+                                                 })).value
+
+
 def dry_run_xcm_call(
         chain: XcmChain,
         call: GenericCall,
@@ -60,13 +75,7 @@ def dry_run_xcm_call(
         origin: dict,
         final_destination_account: str
 ) -> CallDryRunResult:
-    dry_run_result = chain.access_substrate(
-        lambda substrate: substrate.runtime_call(api="DryRunApi", method="dry_run_call",
-                                                 params={
-                                                     "origin_caller": origin,
-                                                     "call": call,
-                                                     "result_xcms_version": result_xcms_version
-                                                 })).value
+    dry_run_result = dry_run_call(chain, call, result_xcms_version, origin)
 
     dry_run_effects = dry_run_result["Ok"]
     execution_result = dry_run_effects["execution_result"]

--- a/scripts/xcm_transfers/xcm/dry_run/dry_run_transfer.py
+++ b/scripts/xcm_transfers/xcm/dry_run/dry_run_transfer.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass
 
 from scalecodec import GenericCall
 from substrateinterface import SubstrateInterface
 
 from scripts.xcm_transfers.utils.fix_scale_codec import fix_tuple_encoding, fix_substrate_interface
+from scripts.xcm_transfers.utils.weight import Weight
 from scripts.xcm_transfers.xcm.call_payment.call_payment_api import calculate_call_weight
-from scripts.xcm_transfers.xcm.dry_run.dry_run_api import dry_run_xcm_call, dry_run_final_xcm
+from scripts.xcm_transfers.xcm.dry_run.dry_run_api import dry_run_xcm_call, dry_run_final_xcm, dry_run_call
 from scripts.xcm_transfers.utils.log import debug_log, warn_log
 from scripts.xcm_transfers.xcm.dry_run.dry_run_api import dry_run_intermediate_xcm
+from scripts.xcm_transfers.xcm.dry_run.errors import extract_dispatch_error_message
 from scripts.xcm_transfers.xcm.dry_run.events.deposit import find_deposit_amount
 from scripts.xcm_transfers.xcm.dry_run.fund import fund_account_and_then
 from scripts.xcm_transfers.xcm.dry_run.origins import root_origin
@@ -17,11 +20,11 @@ from scripts.xcm_transfers.xcm.registry.transfer_type import determine_transfer_
 from scripts.xcm_transfers.xcm.registry.xcm_chain import XcmChain
 from scripts.xcm_transfers.xcm.registry.xcm_registry import XcmRegistry
 from scripts.xcm_transfers.xcm.versioned_xcm import VerionsedXcm
-from scripts.xcm_transfers.xcm.versioned_xcm_builder import assets
+from scripts.xcm_transfers.xcm.versioned_xcm_builder import assets, xcm_program
 from scripts.xcm_transfers.xcm.xcm_transfer_direction import XcmTransferDirection
 
-class TransferDryRunner:
 
+class TransferDryRunner:
     _registry: XcmRegistry
 
     def __init__(self, registry: XcmRegistry):
@@ -81,6 +84,7 @@ class TransferDryRunner:
         )
 
         _check_origin_call_weight(call, origin_chain)
+        supports_xcm_execute = _detect_supports_xcm_execute(origin_chain)
 
         origin_dry_run_result = dry_run_xcm_call(
             chain=origin_chain,
@@ -132,13 +136,15 @@ class TransferDryRunner:
             raise Exception(f"Deposited amount was not found, final events: {destination_events}")
 
         result = DryRunTransferResult(
-            paid_delivery_fee=paid_delivery_fee
+            paid_delivery_fee=paid_delivery_fee,
+            supports_xcm_execute=supports_xcm_execute
         )
 
         debug_log(
             f"Transfer successfully finished on {destination_chain.chain.name}, result: {result}")
 
         return result
+
 
 def _check_origin_call_weight(
         call: GenericCall,
@@ -154,12 +160,59 @@ def _check_origin_call_weight(
         raise Exception(f"Call weight {weight} exceeds maximum by some dimension")
 
 
+@functools.cache
+def _detect_supports_xcm_execute(xcm_chain: XcmChain) -> bool:
+    print("detect_supports_xcm_execute invoked")
+
+    dry_run_result = xcm_chain.chain.access_substrate(lambda s: _dry_run_empty_xcm_execute(xcm_chain, s))
+
+    execution_result = dry_run_result["Ok"]['execution_result']
+    error = extract_xcm_execute_error(execution_result, xcm_chain)
+
+    if error is None:
+        print(f"Xcm execute status OK")
+    else:
+        print(f"Xcm execute status error: {error}")
+
+    return error is not None
+
+
+def extract_xcm_execute_error(execution_result: dict, xcm_chain: XcmChain) -> str | None:
+    if "Ok" in execution_result:
+        return None
+
+    error = execution_result["Error"]["error"]
+    error_message = extract_dispatch_error_message(xcm_chain, error)
+    # There is some error, but it is not related to xcm execute filter. Probably because we are using empty xcm message
+    # dry run from an empty account. Consider such cases as Ok
+    if "Filtered" not in error_message:
+        return None
+
+    return error_message
+
+
+def _dry_run_empty_xcm_execute(xcm_chain: XcmChain, substrate: SubstrateInterface) -> dict:
+    call = substrate.compose_call(
+        call_module=xcm_chain.xcm_pallet_alias(),
+        call_function="execute",
+        call_params={
+            "message": xcm_program([]).versioned,
+            "max_weight": Weight.zero().to_sdk_value()
+        }
+    )
+
+    return dry_run_call(xcm_chain, call, VerionsedXcm.default_xcm_version(), root_origin())
+
+
 @dataclass
 class DryRunTransferResult:
     paid_delivery_fee: bool
+    supports_xcm_execute: bool
+
 
 _substrate_account = "13mp1WEs72kbCBF3WKcoK6Hfhu2HHZGpQ4jsKCZbfd6FoRvH"
 _evm_account = "0x0c7485f4AA235347BDE0168A59f6c73C7A42ff2C"
+
 
 def _dry_run_account_for_chain(chain: XcmChain) -> str:
     if chain.chain.has_evm_addresses():

--- a/scripts/xcm_transfers/xcm/dry_run/errors.py
+++ b/scripts/xcm_transfers/xcm/dry_run/errors.py
@@ -1,6 +1,5 @@
 from substrateinterface import SubstrateInterface
 
-from scripts.xcm_transfers.utils.log import debug_log
 from scripts.xcm_transfers.xcm.registry.xcm_chain import XcmChain
 
 
@@ -8,7 +7,6 @@ def is_call_run_error(execution_result: dict):
     return "Error" in execution_result
 
 def get_module_error(substrate: SubstrateInterface, module_index: int, error_index: int):
-    debug_log(f"Error index: {module_index}-{error_index}")
     return substrate.metadata.get_module_error(module_index=module_index, error_index=error_index)
 
 def extract_dispatch_error_message(chain: XcmChain, dispatch_error) -> str:
@@ -32,6 +30,7 @@ def handle_call_run_error_execution_result(chain: XcmChain, execution_result: di
     error_description = extract_dispatch_error_message(chain, error)
 
     raise Exception(error_description)
+
 
 def is_xcm_run_error(execution_result: dict):
     return "Incomplete" in execution_result or "Error" in execution_result

--- a/scripts/xcm_transfers/xcm_registry_additional_data.json
+++ b/scripts/xcm_transfers/xcm_registry_additional_data.json
@@ -122,7 +122,7 @@
         "parachainId": 2001,
         "runtimePrefix": "bifrost_kusama_runtime",
         "name": "Bifrost Kusama",
-        "dryRunVersion": 1,
+        "dryRunVersion": 2,
         "xcmOutcomeType": "staging_xcm::v4::traits::Outcome"
     },
     "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755": {

--- a/xcm/v7/transfers_dynamic.json
+++ b/xcm/v7/transfers_dynamic.json
@@ -402,7 +402,8 @@
           "xcmTransfers": [
             {
               "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -411,19 +412,23 @@
           "xcmTransfers": [
             {
               "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
-              "assetId": 7
+              "assetId": 7,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
-              "assetId": 10
+              "assetId": 10,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
-              "assetId": 7
+              "assetId": 7,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755",
-              "assetId": 4
+              "assetId": 4,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -432,11 +437,13 @@
           "xcmTransfers": [
             {
               "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
-              "assetId": 3
+              "assetId": 3,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
-              "assetId": 8
+              "assetId": 8,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -445,46 +452,8 @@
           "xcmTransfers": [
             {
               "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
-              "assetId": 0
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
-      "assets": [
-        {
-          "assetId": 7,
-          "xcmTransfers": [
-            {
-              "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
-              "assetId": 7
-            },
-            {
-              "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
-              "assetId": 7
-            },
-            {
-              "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
-              "assetId": 10
-            },
-            {
-              "chainId": "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755",
-              "assetId": 4
-            }
-          ]
-        },
-        {
-          "assetId": 8,
-          "xcmTransfers": [
-            {
-              "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
-              "assetId": 0
-            },
-            {
-              "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
-              "assetId": 3
+              "assetId": 0,
+              "supportsXcmExecute": true
             }
           ]
         }
@@ -604,19 +573,23 @@
           "xcmTransfers": [
             {
               "chainId": "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
-              "assetId": 0
+              "assetId": 0,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b",
-              "assetId": 2
+              "assetId": 2,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -625,15 +598,18 @@
           "xcmTransfers": [
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 2
+              "assetId": 2,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 16
+              "assetId": 16,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -642,15 +618,18 @@
           "xcmTransfers": [
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 0
+              "assetId": 0,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 8
+              "assetId": 8,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b",
-              "assetId": 4
+              "assetId": 4,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -659,23 +638,28 @@
           "xcmTransfers": [
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 9
+              "assetId": 9,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 9
+              "assetId": 9,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b",
-              "assetId": 3
+              "assetId": 3,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "7eb9354488318e7549c722669dcbdcdc526f1fef1420e7944667212f3601fdbd",
-              "assetId": 2
+              "assetId": 2,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -684,15 +668,18 @@
           "xcmTransfers": [
             {
               "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
-              "assetId": 2
+              "assetId": 2,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 15
+              "assetId": 15,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "7eb9354488318e7549c722669dcbdcdc526f1fef1420e7944667212f3601fdbd",
-              "assetId": 3
+              "assetId": 3,
+              "supportsXcmExecute": true
             }
           ]
         }
@@ -927,19 +914,23 @@
           "xcmTransfers": [
             {
               "chainId": "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
-              "assetId": 0
+              "assetId": 0,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -948,15 +939,18 @@
           "xcmTransfers": [
             {
               "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
-              "assetId": 0
+              "assetId": 0,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 2
+              "assetId": 2,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 16
+              "assetId": 16,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -965,23 +959,28 @@
           "xcmTransfers": [
             {
               "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
-              "assetId": 10
+              "assetId": 10,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 9
+              "assetId": 9,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 9
+              "assetId": 9,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "7eb9354488318e7549c722669dcbdcdc526f1fef1420e7944667212f3601fdbd",
-              "assetId": 2
+              "assetId": 2,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -990,15 +989,18 @@
           "xcmTransfers": [
             {
               "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
-              "assetId": 8
+              "assetId": 8,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 0
+              "assetId": 0,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 8
+              "assetId": 8,
+              "supportsXcmExecute": true
             }
           ]
         }

--- a/xcm/v7/transfers_dynamic.json
+++ b/xcm/v7/transfers_dynamic.json
@@ -424,11 +424,6 @@
               "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
               "assetId": 7,
               "supportsXcmExecute": true
-            },
-            {
-              "chainId": "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755",
-              "assetId": 4,
-              "supportsXcmExecute": true
             }
           ]
         },
@@ -453,6 +448,51 @@
             {
               "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
               "assetId": 0,
+              "supportsXcmExecute": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
+      "assets": [
+        {
+          "assetId": 7,
+          "xcmTransfers": [
+            {
+              "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+              "assetId": 7,
+              "supportsXcmExecute": true
+            },
+            {
+              "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
+              "assetId": 7,
+              "supportsXcmExecute": true
+            },
+            {
+              "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
+              "assetId": 10,
+              "supportsXcmExecute": true
+            },
+            {
+              "chainId": "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755",
+              "assetId": 4,
+              "supportsXcmExecute": true
+            }
+          ]
+        },
+        {
+          "assetId": 8,
+          "xcmTransfers": [
+            {
+              "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
+              "assetId": 0,
+              "supportsXcmExecute": true
+            },
+            {
+              "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
+              "assetId": 3,
               "supportsXcmExecute": true
             }
           ]

--- a/xcm/v7/transfers_dynamic_dev.json
+++ b/xcm/v7/transfers_dynamic_dev.json
@@ -564,11 +564,6 @@
               "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
               "assetId": 7,
               "supportsXcmExecute": true
-            },
-            {
-              "chainId": "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755",
-              "assetId": 4,
-              "supportsXcmExecute": true
             }
           ]
         },
@@ -593,6 +588,51 @@
             {
               "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
               "assetId": 0,
+              "supportsXcmExecute": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
+      "assets": [
+        {
+          "assetId": 7,
+          "xcmTransfers": [
+            {
+              "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+              "assetId": 7,
+              "supportsXcmExecute": true
+            },
+            {
+              "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
+              "assetId": 7,
+              "supportsXcmExecute": true
+            },
+            {
+              "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
+              "assetId": 10,
+              "supportsXcmExecute": true
+            },
+            {
+              "chainId": "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755",
+              "assetId": 4,
+              "supportsXcmExecute": true
+            }
+          ]
+        },
+        {
+          "assetId": 8,
+          "xcmTransfers": [
+            {
+              "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
+              "assetId": 0,
+              "supportsXcmExecute": true
+            },
+            {
+              "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
+              "assetId": 3,
               "supportsXcmExecute": true
             }
           ]

--- a/xcm/v7/transfers_dynamic_dev.json
+++ b/xcm/v7/transfers_dynamic_dev.json
@@ -542,7 +542,8 @@
           "xcmTransfers": [
             {
               "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -551,19 +552,23 @@
           "xcmTransfers": [
             {
               "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
-              "assetId": 7
+              "assetId": 7,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
-              "assetId": 10
+              "assetId": 10,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
-              "assetId": 7
+              "assetId": 7,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755",
-              "assetId": 4
+              "assetId": 4,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -572,11 +577,13 @@
           "xcmTransfers": [
             {
               "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
-              "assetId": 3
+              "assetId": 3,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
-              "assetId": 8
+              "assetId": 8,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -585,46 +592,8 @@
           "xcmTransfers": [
             {
               "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
-              "assetId": 0
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
-      "assets": [
-        {
-          "assetId": 7,
-          "xcmTransfers": [
-            {
-              "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
-              "assetId": 7
-            },
-            {
-              "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
-              "assetId": 7
-            },
-            {
-              "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
-              "assetId": 10
-            },
-            {
-              "chainId": "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755",
-              "assetId": 4
-            }
-          ]
-        },
-        {
-          "assetId": 8,
-          "xcmTransfers": [
-            {
-              "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
-              "assetId": 0
-            },
-            {
-              "chainId": "f1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108",
-              "assetId": 3
+              "assetId": 0,
+              "supportsXcmExecute": true
             }
           ]
         }
@@ -744,19 +713,23 @@
           "xcmTransfers": [
             {
               "chainId": "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
-              "assetId": 0
+              "assetId": 0,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b",
-              "assetId": 2
+              "assetId": 2,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -765,15 +738,18 @@
           "xcmTransfers": [
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 2
+              "assetId": 2,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 16
+              "assetId": 16,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -782,15 +758,18 @@
           "xcmTransfers": [
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 0
+              "assetId": 0,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 8
+              "assetId": 8,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b",
-              "assetId": 4
+              "assetId": 4,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -799,23 +778,28 @@
           "xcmTransfers": [
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 9
+              "assetId": 9,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 9
+              "assetId": 9,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b",
-              "assetId": 3
+              "assetId": 3,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "7eb9354488318e7549c722669dcbdcdc526f1fef1420e7944667212f3601fdbd",
-              "assetId": 2
+              "assetId": 2,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -824,15 +808,18 @@
           "xcmTransfers": [
             {
               "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
-              "assetId": 2
+              "assetId": 2,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 15
+              "assetId": 15,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "7eb9354488318e7549c722669dcbdcdc526f1fef1420e7944667212f3601fdbd",
-              "assetId": 3
+              "assetId": 3,
+              "supportsXcmExecute": true
             }
           ]
         }
@@ -1067,19 +1054,23 @@
           "xcmTransfers": [
             {
               "chainId": "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
-              "assetId": 0
+              "assetId": 0,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -1088,15 +1079,18 @@
           "xcmTransfers": [
             {
               "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
-              "assetId": 0
+              "assetId": 0,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 2
+              "assetId": 2,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 16
+              "assetId": 16,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -1105,23 +1099,28 @@
           "xcmTransfers": [
             {
               "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
-              "assetId": 10
+              "assetId": 10,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 9
+              "assetId": 9,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
-              "assetId": 1
+              "assetId": 1,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 9
+              "assetId": 9,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "7eb9354488318e7549c722669dcbdcdc526f1fef1420e7944667212f3601fdbd",
-              "assetId": 2
+              "assetId": 2,
+              "supportsXcmExecute": true
             }
           ]
         },
@@ -1130,15 +1129,18 @@
           "xcmTransfers": [
             {
               "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
-              "assetId": 8
+              "assetId": 8,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
-              "assetId": 0
+              "assetId": 0,
+              "supportsXcmExecute": true
             },
             {
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
-              "assetId": 8
+              "assetId": 8,
+              "supportsXcmExecute": true
             }
           ]
         }


### PR DESCRIPTION
* Check that `XcmExecuteFilter` is not equal to `Nothing` by performing a dry run of `polkadotXcm.execute` with an empty xcm message. Fill `supprotsXcmExecute` flag in the config based on the result
* Optimize retry upon reconnect - retry only upon actually facining the connection exception and not on any exception. This greatly optimizes the execution especially in the case of nested `access_substrate` calls: the number of retries was `2^nestedness`