### PR TITLE
Rework access_substrate recovery

### DIFF
--- a/scripts/utils/chain_model.py
+++ b/scripts/utils/chain_model.py
@@ -8,6 +8,7 @@ from substrateinterface import SubstrateInterface
 
 from .metadata_interaction import get_properties
 from .substrate_interface import create_connection_by_url
+from ..xcm_transfers.utils.log import debug_log
 
 T = TypeVar('T')
 
@@ -23,6 +24,8 @@ class Chain:
     _type_registry: dict
 
     _type_cache: dict = {}
+
+    _access_substrate_counter: int = 0
 
     def __init__(self, arg, type_registry=None):
         self.chainId = arg.get("chainId")
@@ -100,15 +103,19 @@ class Chain:
             self.create_connection()
 
         try:
+            self._access_substrate_counter += 1
             return action(self.substrate)
         except Exception as e:
-            if self._is_connection_broken_error(e):
-                print("Attempting to re-create connection after broken connection", e)
+            if self._access_substrate_counter == 1:
+                print("Attempting to re-create connection after broken connection:", e)
                 # try re-connecting socket and performing action once again
                 self.recreate_connection()
                 return action(self.substrate)
             else:
+                debug_log("Nested access_substrate - propagate error to the outer-most level")
                 raise e
+        finally:
+            self._access_substrate_counter -= 1
 
     def encodable_address(self, account_id: str):
         if self.has_evm_addresses():
@@ -121,16 +128,6 @@ class Chain:
     def _uses_multi_address(self) -> bool:
         type_def = self.substrate.get_type_definition("Address")
         return type_def is dict
-
-    @staticmethod
-    def _is_connection_broken_error(e: Exception) -> bool:
-        message = str(e)
-        return message in {
-            "Expecting value: line 1 column 1 (char 0)",
-            "Failure Connection to remote host was lost.",
-            "Failure EOF occurred in violation of protocol (_ssl.c:2406)"
-        }
-
 
 class ChainAsset:
     _data: dict

--- a/scripts/utils/chain_model.py
+++ b/scripts/utils/chain_model.py
@@ -125,7 +125,11 @@ class Chain:
     @staticmethod
     def _is_connection_broken_error(e: Exception) -> bool:
         message = str(e)
-        return message in {"Expecting value: line 1 column 1 (char 0)", "Failure Connection to remote host was lost."}
+        return message in {
+            "Expecting value: line 1 column 1 (char 0)",
+            "Failure Connection to remote host was lost.",
+            "Failure EOF occurred in violation of protocol (_ssl.c:2406)"
+        }
 
 
 class ChainAsset:

--- a/scripts/xcm_transfers/dry_run_sample.py
+++ b/scripts/xcm_transfers/dry_run_sample.py
@@ -7,10 +7,10 @@ from scripts.xcm_transfers.xcm.xcm_transfer_direction import XcmTransferDirectio
 config_files = get_xcm_config_files()
 registry = build_xcm_registry(config_files)
 
-origin_chain_name = "Bifrost Kusama"
-destination_chain_name = "Kusama"
-origin_token = "KSM"
-destination_token = "KSM"
+origin_chain_name = "Polkadot Asset Hub"
+destination_chain_name = "Hydration"
+origin_token = "DOT"
+destination_token = "DOT"
 
 origin_chain = registry.get_chain_by_name(origin_chain_name)
 destination_chain = registry.get_chain_by_name(destination_chain_name)


### PR DESCRIPTION
Approach with filtering error messages turned out to be unreliable as there are more and more different errors arise during script's exploitation
New approach just tracks acess_substrate nestendess and propagates all errors to the outermost one so each error will be retried only once