### PR TITLE
fix: update nodes

### DIFF
--- a/chains/v21/chains.json
+++ b/chains/v21/chains.json
@@ -8937,7 +8937,7 @@
         ],
         "nodes": [
             {
-                "url": "wss://acurast-canarynet-ws.prod.gke.papers.tech",
+                "url": "wss://public-rpc.canary.acurast.com",
                 "name": "Acurast node"
             }
         ],

--- a/chains/v21/chains.json
+++ b/chains/v21/chains.json
@@ -458,7 +458,7 @@
                 "name": "IBP2 node"
             },
             {
-                "url": "wss://statemine-rpc.dwellir.com",
+                "url": "wss://asset-hub-kusama-rpc.dwellir.com",
                 "name": "Dwellir node"
             }
         ],
@@ -4127,7 +4127,7 @@
                 "name": "IBP2 node"
             },
             {
-                "url": "wss://statemint-rpc.dwellir.com",
+                "url": "wss://asset-hub-polkadot-rpc.dwellir.com",
                 "name": "Dwellir node"
             },
             {
@@ -7794,10 +7794,6 @@
             {
                 "url": "wss://ajuna.dotters.network",
                 "name": "IBP2 node"
-            },
-            {
-                "url": "wss://ajuna.public.curie.radiumblock.co/ws",
-                "name": "RadiumBlock node"
             }
         ],
         "explorers": [

--- a/chains/v21/chains_dev.json
+++ b/chains/v21/chains_dev.json
@@ -544,7 +544,7 @@
                 "name": "IBP2 node"
             },
             {
-                "url": "wss://statemine-rpc.dwellir.com",
+                "url": "wss://asset-hub-kusama-rpc.dwellir.com",
                 "name": "Dwellir node"
             }
         ],
@@ -4640,7 +4640,7 @@
                 "name": "IBP2 node"
             },
             {
-                "url": "wss://statemint-rpc.dwellir.com",
+                "url": "wss://asset-hub-polkadot-rpc.dwellir.com",
                 "name": "Dwellir node"
             },
             {
@@ -8993,10 +8993,6 @@
             {
                 "url": "wss://ajuna.dotters.network",
                 "name": "IBP2 node"
-            },
-            {
-                "url": "wss://ajuna.public.curie.radiumblock.co/ws",
-                "name": "RadiumBlock node"
             }
         ],
         "explorers": [

--- a/chains/v21/chains_dev.json
+++ b/chains/v21/chains_dev.json
@@ -10985,7 +10985,7 @@
         ],
         "nodes": [
             {
-                "url": "wss://acurast-canarynet-ws.prod.gke.papers.tech",
+                "url": "wss://public-rpc.canary.acurast.com",
                 "name": "Acurast node"
             }
         ],


### PR DESCRIPTION
- `wss://ajuna.public.curie.radiumblock.co/ws` removed as [not reachabe](https://github.com/polkadot-js/apps/blob/b6ace143df3e14bbf68bc5daa8380c1eb90df942/packages/apps-config/src/endpoints/productionRelayPolkadot.ts#L51)
- `wss://statemint-rpc.dwellir.com`: updated url to [new one](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fasset-hub-polkadot-rpc.dwellir.com#/explorer)
- `wss://statemine-rpc.dwellir.com`: updated url to [new one](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fasset-hub-kusama-rpc.dwellir.com#/explorer)
- `wss://acurast-canarynet-ws.prod.gke.papers.tech`: updated url to [new one](https://github.com/polkadot-js/apps/blob/b6ace143df3e14bbf68bc5daa8380c1eb90df942/packages/apps-config/src/endpoints/productionRelayKusama.ts#L37)