### PR TITLE
fix: update ETH-Snowbridge currencyIdScale on Hydration

### DIFF
--- a/chains/v21/chains.json
+++ b/chains/v21/chains.json
@@ -5591,7 +5591,7 @@
                 "type": "orml",
                 "icon": "WETH-Snowbridge.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x20000000",
+                    "currencyIdScale": "0x22000000",
                     "currencyIdType": "u32",
                     "existentialDeposit": "5373455131650",
                     "transfersEnabled": true

--- a/chains/v21/chains_dev.json
+++ b/chains/v21/chains_dev.json
@@ -5961,7 +5961,7 @@
                 "type": "orml",
                 "icon": "WETH-Snowbridge.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x20000000",
+                    "currencyIdScale": "0x22000000",
                     "currencyIdType": "u32",
                     "existentialDeposit": "5373455131650",
                     "transfersEnabled": true

--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -5615,7 +5615,7 @@
                 "type": "orml",
                 "icon": "WETH-Snowbridge.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x20000000",
+                    "currencyIdScale": "0x22000000",
                     "currencyIdType": "u32",
                     "existentialDeposit": "5373455131650",
                     "transfersEnabled": true

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -5931,7 +5931,7 @@
                 "type": "orml",
                 "icon": "WETH-Snowbridge.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x20000000",
+                    "currencyIdScale": "0x22000000",
                     "currencyIdType": "u32",
                     "existentialDeposit": "5373455131650",
                     "transfersEnabled": true


### PR DESCRIPTION
was mistakenly added here https://github.com/novasamatech/nova-utils/pull/3536
<img width="774" alt="image" src="https://github.com/user-attachments/assets/30be03e9-a082-4ae3-b38f-d6f215a301ce" />

<img width="774" alt="image" src="https://github.com/user-attachments/assets/8bc04630-5944-4841-8f51-53d353e65498" />

