### PR TITLE
promote migrate subquery endpoints to self-hosted indexers v2

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -1378,7 +1378,7 @@
             "governance-delegations": [
                 {
                     "type": "subquery",
-                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-moonbeam-gov"
+                    "url": "https://subquery-governance-moonbeam-prod.novasama-tech.org"
                 }
             ],
             "multisig": [
@@ -1834,7 +1834,7 @@
             "governance-delegations": [
                 {
                     "type": "subquery",
-                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-moonriver-gov"
+                    "url": "https://subquery-governance-moonriver-prod.novasama-tech.org"
                 }
             ]
         },
@@ -3562,7 +3562,7 @@
             "history": [
                 {
                     "type": "subquery",
-                    "url": "https://gateway.subquery.network/query/0x1f"
+                    "url": "https://subquery-history-astar-prod.novasama-tech.org"
                 }
             ]
         },
@@ -6287,13 +6287,13 @@
             "history": [
                 {
                     "type": "subquery",
-                    "url": "https://gateway.subquery.network/query/0x1c"
+                    "url": "https://subquery-history-aleph-zero-prod.novasama-tech.org"
                 }
             ],
             "staking": [
                 {
                     "type": "subquery",
-                    "url": "https://gateway.subquery.network/query/0x1c"
+                    "url": "https://subquery-history-aleph-zero-prod.novasama-tech.org"
                 }
             ]
         },
@@ -7276,7 +7276,7 @@
             "history": [
                 {
                     "type": "subquery",
-                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-polymesh"
+                    "url": "https://subquery-history-polymesh-prod.novasama-tech.org"
                 }
             ]
         }
@@ -7723,7 +7723,7 @@
             "history": [
                 {
                     "type": "subquery",
-                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-crust"
+                    "url": "https://subquery-history-crust-prod.novasama-tech.org"
                 }
             ]
         },
@@ -7871,7 +7871,7 @@
             "history": [
                 {
                     "type": "subquery",
-                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bittensor"
+                    "url": "https://subquery-history-bittensor-prod.novasama-tech.org"
                 }
             ]
         },
@@ -8459,7 +8459,7 @@
             "history": [
                 {
                     "type": "subquery",
-                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet---joystream"
+                    "url": "https://subquery-history-joystream-prod.novasama-tech.org"
                 }
             ]
         },


### PR DESCRIPTION
promotes https://github.com/novasamatech/nova-utils/pull/3863

* except Moonbeam/Moonriver staking projects as they are [still not indexed yet](https://grafana.novasama-tech.org/d/cdh5gd24cofeod/subquery-overview?from=now-1h&orgId=1&refresh=1m&timezone=browser&to=now&var-env=prod&var-project=subquery-history) therefore rewards difference can be found on multistaking dashboard and staking details

