### PR TITLE
fix: update Edgeware nodes

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -2507,16 +2507,8 @@
         ],
         "nodes": [
             {
-                "url": "wss://edgeware-rpc.dwellir.com",
-                "name": "Dwellir node"
-            },
-            {
-                "url": "wss://edgeware.jelliedowl.net",
+                "url": "wss://edgeware-rpc3.jelliedowl.net",
                 "name": "JelliedOwl node"
-            },
-            {
-                "url": "wss://mainnet2.edgewa.re",
-                "name": "Edgeware node"
             }
         ],
         "explorers": [

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -2155,16 +2155,8 @@
         ],
         "nodes": [
             {
-                "url": "wss://edgeware-rpc.dwellir.com",
-                "name": "Dwellir node"
-            },
-            {
-                "url": "wss://edgeware.jelliedowl.net",
+                "url": "wss://edgeware-rpc3.jelliedowl.net",
                 "name": "JelliedOwl node"
-            },
-            {
-                "url": "wss://mainnet2.edgewa.re",
-                "name": "Edgeware node"
             }
         ],
         "explorers": [


### PR DESCRIPTION
according to balance tests balances of Edgware [failes](https://novasamatech.github.io/balances_test_result/1236/index.html#suites/5b2d42e0a857680774231b52e3cf7d67/d9763774152a3bb/history)

[PolkadotJS endpoints](https://github.com/polkadot-js/apps/blob/master/packages/apps-config/src/endpoints/production.ts)

<img width="3024" height="1890" alt="image" src="https://github.com/user-attachments/assets/82857ddf-dacc-4940-963f-fe2010f219a6" />

<img width="3248" height="2112" alt="image" src="https://github.com/user-attachments/assets/41e82493-6a9e-4066-9fe1-8d254bc69f73" />
