### PR TITLE
fix: update xcCFG contractAddress

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -1192,7 +1192,7 @@
                 "priceId": "centrifuge",
                 "icon": "CFG.svg",
                 "typeExtras": {
-                    "contractAddress": "0xFffFFfFf8f6267e040D8a0638C576dfBa4F0F6D6"
+                    "contractAddress": "0xFFfFfFff44bD9D2FFEE20B25D1Cf9E78Edb6Eae3"
                 }
             },
             {

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -3468,7 +3468,7 @@
                 "priceId": "centrifuge",
                 "icon": "CFG.svg",
                 "typeExtras": {
-                    "contractAddress": "0xFffFFfFf8f6267e040D8a0638C576dfBa4F0F6D6"
+                    "contractAddress": "0xFFfFfFff44bD9D2FFEE20B25D1Cf9E78Edb6Eae3"
                 }
             },
             {


### PR DESCRIPTION
https://moonscan.io/token/0xffffffff44bd9d2ffee20b25d1cf9e78edb6eae3
https://moonbeam.subscan.io/token/0xffffffff44bd9d2ffee20b25d1cf9e78edb6eae3


Investigation: was mistakenly taken from xcEQ contracAddress and added:
https://github.com/novasamatech/nova-utils/pull/3785/files

<img width="3024" height="1890" alt="image" src="https://github.com/user-attachments/assets/5c84a120-0742-4865-80bb-03cc50311996" />
