### PR TITLE
Disabling xcm execute support for PAH.MYTH <> Mythos.MYTH direction

### DIFF
--- a/xcm/v7/transfers_dynamic_dev.json
+++ b/xcm/v7/transfers_dynamic_dev.json
@@ -927,7 +927,7 @@
               "chainId": "f6ee56e9c5277df5b4ce6ae9983ee88f3cbed27d31beeb98f9f84f997a1ab0b9",
               "assetId": 0,
               "hasDeliveryFee": true,
-              "supportsXcmExecute": true
+              "supportsXcmExecute": false
             }
           ]
         }


### PR DESCRIPTION
Temporary disabling of xcm execute support for PAH.Myth <> Mythos.MYTH direction