### PR TITLE
Disabling of SupportsXcmExecute for Mythos.MYTH directions (Dev)

### DIFF
--- a/xcm/v8/transfers_dynamic_dev.json
+++ b/xcm/v8/transfers_dynamic_dev.json
@@ -1280,7 +1280,7 @@
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
               "assetId": 36,
               "hasDeliveryFee": true,
-              "supportsXcmExecute": true
+              "supportsXcmExecute": false
             }
           ]
         }


### PR DESCRIPTION
Temporary disabling of SupportsXcmExecute for Mythos.MYTH directions (Dev)