### PR TITLE
Disable supportsXcmExecute on Mythos

### DIFF
--- a/xcm/v8/transfers_dynamic.json
+++ b/xcm/v8/transfers_dynamic.json
@@ -1085,7 +1085,7 @@
               "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
               "assetId": 36,
               "hasDeliveryFee": true,
-              "supportsXcmExecute": true
+              "supportsXcmExecute": false
             }
           ]
         }


### PR DESCRIPTION
### SUMMARY
The PR manually disables `xcm.execute` for Mythos chain.