### PR TITLE
promote fix Kusama ed, KAH fee, migration block start

### DIFF
--- a/migrations/asset_hub/migrations.json
+++ b/migrations/asset_hub/migrations.json
@@ -3,24 +3,24 @@
     "sourceData": {
         "chainId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
         "assetId": 0,
-        "minBalance": "333333333",
-        "averageFee": "5000000"
+        "minBalance": "33333333",
+        "averageFee": "530000000"
     },
     "destinationData": {
         "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
         "assetId": 0,
         "minBalance": "3333333",
-        "averageFee": "500000"
+        "averageFee": "90000000"
     },
-    "blockNumber": 30416344,
+    "blockNumber": 30423691,
     "timestamp": 1759795200,
     "newTokenNames": [
         "USDT",
         "USDC",
-        "ETH",
         "DOT"
     ],
     "bannerPath": "ahm_kusama",
-    "wikiURL": "https://docs.novawallet.io/nova-wallet-wiki/"
+    "migrationInProgress": true,
+    "wikiURL": "https://docs.novawallet.io/nova-wallet-wiki/asset-management/asset-hub-migration-faq"
   }
 ]

--- a/migrations/asset_hub/migrations_dev.json
+++ b/migrations/asset_hub/migrations_dev.json
@@ -42,7 +42,6 @@
     "newTokenNames": [
         "USDT",
         "USDC",
-        "ETH",
         "DOT"
     ],
     "bannerPath": "ahm_kusama",


### PR DESCRIPTION
* promotes changes here: https://github.com/novasamatech/nova-utils/pull/4029
* removes ETH from KAH text
* test ETH removal on dev

![IMAGE 2025-10-03 11:57:24](https://github.com/user-attachments/assets/93b5d6c2-b527-4bea-8fa4-7c0aefe41948)
