### PR TITLE
Fix banner's name in migration config (Dev)

### DIFF
--- a/migrations/asset_hub/migrations_dev.json
+++ b/migrations/asset_hub/migrations_dev.json
@@ -20,7 +20,7 @@
         "ETH",
         "DOT"
     ],
-    "bannerPath": "ahm_kusama_inprogress",
+    "bannerPath": "ahm_kusama",
     "migrationInProgress": false,
     "wikiURL": "https://docs.novawallet.io/nova-wallet-wiki/asset-management/asset-hub-migration-faq"
   },


### PR DESCRIPTION
Fix banner's name to prevent "Migration info not found" on iOS