### PR TITLE
Add 2 Polkadot validators to preferred list

### DIFF
--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -8359,6 +8359,10 @@
             {
                 "url": "wss://rpc.vara-network.io",
                 "name": "Gear Tech node"
+            },
+            {
+                "url": "wss://rpc.vara.network",
+                "name": "Gear Tech node 2"
             }
         ],
         "explorers": [

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -8357,11 +8357,11 @@
         ],
         "nodes": [
             {
-                "url": "wss://rpc.vara-network.io",
+                "url": "wss://rpc.vara.network",
                 "name": "Gear Tech node"
             },
             {
-                "url": "wss://rpc.vara.network",
+                "url": "wss://rpc.vara-network.io",
                 "name": "Gear Tech node 2"
             }
         ],

--- a/staking/validators/v1/nova_validators.json
+++ b/staking/validators/v1/nova_validators.json
@@ -4,7 +4,9 @@
       "127zarPDhVzmCXVQ7Kfr1yyaa9wsMuJ74GJW9Q7ezHfQEgh6",
       "13JuwkvSqGUDo8zErgfC9ivGfKfcdDyceFkvh9NW4wz7NbuF",
       "15yWjJfhPwiBECjVezPTA42EFpcrxmRUjzPN6nf3azvZ5wDX",
-      "15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu"
+      "15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu",
+      "151oCCvw1aZS8TZHzvAj6J3zJec7ZLEKRj6FVWhzVGbTXTG1",
+      "16LLBgPW338sbqCkxHpKGpZB9P9y7nnaMSZFodUhpb3bs1H3"
     ],
     "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe": [
       "DhK6qU2U5kDWeJKvPRtmnWRs8ETUGZ9S9QmNmQFuzrNoKm4",
@@ -38,7 +40,9 @@
       "127zarPDhVzmCXVQ7Kfr1yyaa9wsMuJ74GJW9Q7ezHfQEgh6",
       "13JuwkvSqGUDo8zErgfC9ivGfKfcdDyceFkvh9NW4wz7NbuF",
       "15yWjJfhPwiBECjVezPTA42EFpcrxmRUjzPN6nf3azvZ5wDX",
-      "15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu"
+      "15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu",
+      "151oCCvw1aZS8TZHzvAj6J3zJec7ZLEKRj6FVWhzVGbTXTG1",
+      "16LLBgPW338sbqCkxHpKGpZB9P9y7nnaMSZFodUhpb3bs1H3"
     ]
   },
   "excluded": {

--- a/staking/validators/v1/nova_validators_dev.json
+++ b/staking/validators/v1/nova_validators_dev.json
@@ -4,7 +4,9 @@
       "127zarPDhVzmCXVQ7Kfr1yyaa9wsMuJ74GJW9Q7ezHfQEgh6",
       "13JuwkvSqGUDo8zErgfC9ivGfKfcdDyceFkvh9NW4wz7NbuF",
       "15yWjJfhPwiBECjVezPTA42EFpcrxmRUjzPN6nf3azvZ5wDX",
-      "15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu"
+      "15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu",
+      "151oCCvw1aZS8TZHzvAj6J3zJec7ZLEKRj6FVWhzVGbTXTG1",
+      "16LLBgPW338sbqCkxHpKGpZB9P9y7nnaMSZFodUhpb3bs1H3"
     ],
     "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe": [
       "DhK6qU2U5kDWeJKvPRtmnWRs8ETUGZ9S9QmNmQFuzrNoKm4",
@@ -38,7 +40,9 @@
       "127zarPDhVzmCXVQ7Kfr1yyaa9wsMuJ74GJW9Q7ezHfQEgh6",
       "13JuwkvSqGUDo8zErgfC9ivGfKfcdDyceFkvh9NW4wz7NbuF",
       "15yWjJfhPwiBECjVezPTA42EFpcrxmRUjzPN6nf3azvZ5wDX",
-      "15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu"
+      "15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu",
+      "151oCCvw1aZS8TZHzvAj6J3zJec7ZLEKRj6FVWhzVGbTXTG1",
+      "16LLBgPW338sbqCkxHpKGpZB9P9y7nnaMSZFodUhpb3bs1H3"
     ]
   },
   "excluded": {


### PR DESCRIPTION
Adds 2 validators to the Polkadot preferred list:

- `151oCCvw1aZS8TZHzvAj6J3zJec7ZLEKRj6FVWhzVGbTXTG1`
- `16LLBgPW338sbqCkxHpKGpZB9P9y7nnaMSZFodUhpb3bs1H3`

Applied to both the Polkadot relay entry (`91b171bb...`) and the Polkadot Asset Hub entry (`68d56f15...`), in both `nova_validators.json` (prod) and `nova_validators_dev.json` (dev). Final preferred count per entry: 4 → 6.

These two validators are now in the active set, so I believe we can start reccomending them.