### PR TITLE
Mythos node update (dev)

### DIFF
--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -10011,8 +10011,8 @@
         ],
         "nodes": [
             {
-                "url": "wss://polkadot-mythos-rpc.polkadot.io",
-                "name": "Parity node",
+                "url": "wss://mythos-rpc.dmarket.com",
+                "name": "DMarket node",
                 "features": [
                     "noTls12"
                 ]


### PR DESCRIPTION
Mythos node update due to the shutdown of the current public one on April 30, 2026 (dev env).