### PR TITLE
Add staking_notices.json for per-chain staking notices

### DIFF
--- a/notices/staking_notices.json
+++ b/notices/staking_notices.json
@@ -1,6 +1,6 @@
 [
   {
-    "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1c4b2599b87487420976a",
+    "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
     "severity": "critical",
     "shortText": "Migrate by Aug 1, 2026",
     "longText": "The Manta Atlantic parachain slot expires August 1, 2026. Manta Network is consolidating on Manta Pacific. Unstake your MANTA and migrate before this date to avoid losing access to your funds.",

--- a/notices/staking_notices.json
+++ b/notices/staking_notices.json
@@ -2,14 +2,8 @@
   {
     "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
     "severity": "critical",
-    "shortText": "Migrate by Aug 1, 2026",
-    "longText": "The Manta Atlantic parachain slot expires August 1, 2026. Manta Network is consolidating on Manta Pacific. Unstake your MANTA and migrate before this date to avoid losing access to your funds.",
+    "shortText": "Manta Atlantic is shutting down",
+    "longText": "Staking on Manta Atlantic will stop earning rewards on 20th May 2026. The parachain will go offline on 1st August 2026. Users with MANTA tokens should unstake and migrate before this deadline to avoid losing access to your funds. Please consult the Manta project's website and social feeds for more information.",
     "endDate": "2026-08-01"
-  },
-  {
-    "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
-    "severity": "info",
-    "shortText": "Validator program update",
-    "longText": "Aleph Zero is transitioning its validator program. Rewards may pause briefly during the next era. No action required."
   }
 ]

--- a/notices/staking_notices.json
+++ b/notices/staking_notices.json
@@ -2,8 +2,38 @@
   {
     "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
     "severity": "critical",
-    "shortText": "Manta Atlantic is shutting down",
-    "longText": "Staking on Manta Atlantic will stop earning rewards on 20th May 2026. The parachain will go offline on 1st August 2026. Users with MANTA tokens should unstake and migrate before this deadline to avoid losing access to your funds. Please consult the Manta project's website and social feeds for more information.",
+    "shortText": {
+      "en": "Manta Atlantic is shutting down",
+      "es": "Manta Atlantic va a cerrar",
+      "fr": "Manta Atlantic va fermer",
+      "hu": "A Manta Atlantic leáll",
+      "id": "Manta Atlantic akan ditutup",
+      "it": "Manta Atlantic sta chiudendo",
+      "ja": "Manta Atlanticは終了します",
+      "ko": "Manta Atlantic이 종료됩니다",
+      "pl": "Manta Atlantic zostanie zamknięty",
+      "pt-PT": "A Manta Atlantic vai encerrar",
+      "ru": "Manta Atlantic закрывается",
+      "tr": "Manta Atlantic kapatılıyor",
+      "vi": "Manta Atlantic sắp ngừng hoạt động",
+      "zh-Hans": "Manta Atlantic 即将关闭"
+    },
+    "longText": {
+      "en": "Staking on Manta Atlantic will stop earning rewards on 20th May 2026. The parachain will go offline on 1st August 2026. Users with MANTA tokens should unstake and migrate before this deadline to avoid losing access to your funds. Please consult the Manta project's website and social feeds for more information.",
+      "es": "El staking en Manta Atlantic dejará de generar recompensas el 20 de mayo de 2026. La parachain se desconectará el 1 de agosto de 2026. Los usuarios con tokens MANTA deben hacer unstake y migrar antes de esta fecha límite para evitar perder el acceso a sus fondos. Consulta el sitio web y las redes sociales del proyecto Manta para obtener más información.",
+      "fr": "Le staking sur Manta Atlantic cessera de générer des récompenses le 20 mai 2026. La parachain sera mise hors ligne le 1er août 2026. Les utilisateurs détenant des tokens MANTA doivent procéder à l'unstake et migrer avant cette date limite pour éviter de perdre l'accès à leurs fonds. Veuillez consulter le site web et les réseaux sociaux du projet Manta pour plus d'informations.",
+      "hu": "A Manta Atlantic staking 2026. május 20-án megszűnik jutalmakat termelni. A parachain 2026. augusztus 1-jén lekapcsol. A MANTA tokennel rendelkező felhasználóknak ezen határidő előtt unstake-elniük és migrálniuk kell, hogy ne veszítsék el a hozzáférést az eszközeikhez. További információért keresse fel a Manta projekt weboldalát és közösségi csatornáit.",
+      "id": "Staking di Manta Atlantic akan berhenti menghasilkan reward pada 20 Mei 2026. Parachain akan offline pada 1 Agustus 2026. Pengguna yang memiliki token MANTA harus melakukan unstake dan migrasi sebelum batas waktu ini untuk menghindari kehilangan akses ke dana Anda. Silakan kunjungi situs web dan media sosial proyek Manta untuk informasi lebih lanjut.",
+      "it": "Lo staking su Manta Atlantic smetterà di generare ricompense il 20 maggio 2026. La parachain andrà offline il 1° agosto 2026. Gli utenti con token MANTA devono effettuare l'unstake e migrare prima di questa scadenza per evitare di perdere l'accesso ai propri fondi. Consulta il sito web e i canali social del progetto Manta per maggiori informazioni.",
+      "ja": "Manta Atlanticでのステーキング報酬の発生は2026年5月20日に終了します。パラチェーンは2026年8月1日にオフラインになります。MANTAトークンをお持ちのユーザーは、資金へのアクセスを失わないよう、この期限までにアンステークと移行を行ってください。詳細についてはMantaプロジェクトのウェブサイトおよびソーシャルメディアをご確認ください。",
+      "ko": "Manta Atlantic의 스테이킹 보상 지급이 2026년 5월 20일에 중단됩니다. 파라체인은 2026년 8월 1일에 오프라인으로 전환됩니다. MANTA 토큰을 보유한 사용자는 자금에 대한 접근 권한을 잃지 않도록 이 기한 이전에 언스테이킹 및 마이그레이션을 완료해야 합니다. 자세한 내용은 Manta 프로젝트의 웹사이트와 소셜 미디어를 참고해 주세요.",
+      "pl": "Staking na Manta Atlantic przestanie generować nagrody 20 maja 2026 r. Parachain zostanie wyłączony 1 sierpnia 2026 r. Użytkownicy posiadający tokeny MANTA powinni wykonać unstake i migrację przed tym terminem, aby nie stracić dostępu do swoich środków. Więcej informacji można znaleźć na stronie internetowej i w mediach społecznościowych projektu Manta.",
+      "pt-PT": "O staking na Manta Atlantic deixará de gerar recompensas a 20 de maio de 2026. A parachain ficará offline a 1 de agosto de 2026. Os utilizadores com tokens MANTA devem fazer unstake e migrar antes deste prazo para evitar perder o acesso aos seus fundos. Consulte o website e as redes sociais do projeto Manta para obter mais informações.",
+      "ru": "Начисление вознаграждений за стейкинг на Manta Atlantic прекратится 20 мая 2026 года. Парачейн будет отключён 1 августа 2026 года. Пользователям с токенами MANTA необходимо вывести их из стейкинга и выполнить миграцию до этой даты, чтобы не потерять доступ к своим средствам. Подробную информацию можно найти на сайте проекта Manta и в его социальных сетях.",
+      "tr": "Manta Atlantic üzerinde staking 20 Mayıs 2026'da ödül kazanmayı durduracaktır. Parachain 1 Ağustos 2026'da çevrimdışı olacaktır. MANTA token'ı olan kullanıcılar, fonlarına erişimi kaybetmemek için bu son tarihten önce unstake yapmalı ve geçiş işlemini tamamlamalıdır. Daha fazla bilgi için lütfen Manta projesinin web sitesini ve sosyal medya hesaplarını inceleyin.",
+      "vi": "Việc staking trên Manta Atlantic sẽ ngừng tạo phần thưởng vào ngày 20 tháng 5 năm 2026. Parachain sẽ ngoại tuyến vào ngày 1 tháng 8 năm 2026. Người dùng có token MANTA nên unstake và di chuyển tài sản trước thời hạn này để tránh mất quyền truy cập vào số tiền của mình. Vui lòng tham khảo trang web và các kênh mạng xã hội của dự án Manta để biết thêm thông tin.",
+      "zh-Hans": "Manta Atlantic 的质押将于 2026 年 5 月 20 日停止产生奖励。平行链将于 2026 年 8 月 1 日下线。持有 MANTA 代币的用户应在此截止日期前解除质押并迁移资产，以免失去对资金的访问权限。请访问 Manta 项目的官方网站和社交媒体渠道以了解更多信息。"
+    },
     "endDate": "2026-08-01"
   }
 ]

--- a/notices/staking_notices.json
+++ b/notices/staking_notices.json
@@ -1,0 +1,15 @@
+[
+  {
+    "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1c4b2599b87487420976a",
+    "severity": "critical",
+    "shortText": "Migrate by Aug 1, 2026",
+    "longText": "The Manta Atlantic parachain slot expires August 1, 2026. Manta Network is consolidating on Manta Pacific. Unstake your MANTA and migrate before this date to avoid losing access to your funds.",
+    "endDate": "2026-08-01"
+  },
+  {
+    "chainId": "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e",
+    "severity": "info",
+    "shortText": "Validator program update",
+    "longText": "Aleph Zero is transitioning its validator program. Rewards may pause briefly during the next era. No action required."
+  }
+]

--- a/notices/staking_notices.schema.json
+++ b/notices/staking_notices.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/notices/staking_notices.schema.json",
+  "title": "StakingNotices",
+  "description": "Per-chain staking notices displayed in Nova Wallet. v1: shortText/longText are plain strings. v2 will accept locale-map objects.",
+  "type": "array",
+  "items": {
+    "$ref": "#/$defs/StakingNotice"
+  },
+  "$defs": {
+    "LocaleMap": {
+      "type": "object",
+      "description": "Locale-keyed text map (e.g. {\"en\": \"...\", \"zh\": \"...\"}). Reserved for v2.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "LocalizedText": {
+      "description": "Plain string (v1) or locale-map object (v2).",
+      "oneOf": [
+        { "type": "string", "minLength": 1 },
+        { "$ref": "#/$defs/LocaleMap" }
+      ]
+    },
+    "StakingNotice": {
+      "type": "object",
+      "required": ["chainId", "severity", "shortText", "longText"],
+      "additionalProperties": false,
+      "properties": {
+        "chainId": {
+          "type": "string",
+          "description": "64-character lowercase hex chain identifier.",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "severity": {
+          "type": "string",
+          "description": "Notice severity level.",
+          "enum": ["info", "critical"]
+        },
+        "shortText": {
+          "$ref": "#/$defs/LocalizedText",
+          "description": "Brief notice label shown in list and badge contexts."
+        },
+        "longText": {
+          "$ref": "#/$defs/LocalizedText",
+          "description": "Full notice body shown in expanded detail view."
+        },
+        "endDate": {
+          "type": "string",
+          "description": "ISO 8601 date (YYYY-MM-DD) after which the notice is no longer displayed. Omit if the notice has no expiry.",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new JSON document that Nova Wallet apps fetch to display per-chain staking notices without requiring an app release. Each notice is keyed by `chainId` and carries a `severity` (`info` or `critical`), `shortText` (banner/chip text), `longText` (expanded body), and an optional `endDate`. Apps automatically hide notices past their end date.

**`notices/staking_notices.json`** — initial content:
- **Manta Atlantic** (critical) — warns users that the parachain is shutting down: staking rewards stop on 20 May 2026, parachain goes offline on 1 August 2026. Includes 14 localizations.

**`notices/staking_notices.schema.json`** — JSON Schema draft-2020-12 covering:
- `chainId`: 64-character lowercase hex
- `severity`: `info` | `critical`
- `shortText` / `longText`: plain string OR locale-map object (`{"en": "...", "es": "..."}`) — `en` always required
- `endDate`: optional ISO-8601 date (`YYYY-MM-DD`)

## Notes

- iOS consumer: novasamatech/nova-wallet-ios#1830.
- Editing the JSON in this directory has live effect — published notices reach users on their next chains-sync cycle.