### PR TITLE
Bittensor: subtensor staking type + 128 subnet-alpha assets

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -7014,6 +7014,1798 @@
                 "staking": [
                     "subtensor"
                 ]
+            },
+            {
+                "assetId": 10001,
+                "symbol": "SN1",
+                "name": "SN1",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 1
+                }
+            },
+            {
+                "assetId": 10002,
+                "symbol": "SN2",
+                "name": "SN2",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 2
+                }
+            },
+            {
+                "assetId": 10003,
+                "symbol": "SN3",
+                "name": "SN3",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 3
+                }
+            },
+            {
+                "assetId": 10004,
+                "symbol": "SN4",
+                "name": "SN4",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 4
+                }
+            },
+            {
+                "assetId": 10005,
+                "symbol": "SN5",
+                "name": "SN5",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 5
+                }
+            },
+            {
+                "assetId": 10006,
+                "symbol": "SN6",
+                "name": "SN6",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 6
+                }
+            },
+            {
+                "assetId": 10007,
+                "symbol": "SN7",
+                "name": "SN7",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 7
+                }
+            },
+            {
+                "assetId": 10008,
+                "symbol": "SN8",
+                "name": "SN8",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 8
+                }
+            },
+            {
+                "assetId": 10009,
+                "symbol": "SN9",
+                "name": "SN9",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 9
+                }
+            },
+            {
+                "assetId": 10010,
+                "symbol": "SN10",
+                "name": "SN10",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 10
+                }
+            },
+            {
+                "assetId": 10011,
+                "symbol": "SN11",
+                "name": "SN11",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 11
+                }
+            },
+            {
+                "assetId": 10012,
+                "symbol": "SN12",
+                "name": "SN12",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 12
+                }
+            },
+            {
+                "assetId": 10013,
+                "symbol": "SN13",
+                "name": "SN13",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 13
+                }
+            },
+            {
+                "assetId": 10014,
+                "symbol": "SN14",
+                "name": "SN14",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 14
+                }
+            },
+            {
+                "assetId": 10015,
+                "symbol": "SN15",
+                "name": "SN15",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 15
+                }
+            },
+            {
+                "assetId": 10016,
+                "symbol": "SN16",
+                "name": "SN16",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 16
+                }
+            },
+            {
+                "assetId": 10017,
+                "symbol": "SN17",
+                "name": "SN17",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 17
+                }
+            },
+            {
+                "assetId": 10018,
+                "symbol": "SN18",
+                "name": "SN18",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 18
+                }
+            },
+            {
+                "assetId": 10019,
+                "symbol": "SN19",
+                "name": "SN19",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 19
+                }
+            },
+            {
+                "assetId": 10020,
+                "symbol": "SN20",
+                "name": "SN20",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 20
+                }
+            },
+            {
+                "assetId": 10021,
+                "symbol": "SN21",
+                "name": "SN21",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 21
+                }
+            },
+            {
+                "assetId": 10022,
+                "symbol": "SN22",
+                "name": "SN22",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 22
+                }
+            },
+            {
+                "assetId": 10023,
+                "symbol": "SN23",
+                "name": "SN23",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 23
+                }
+            },
+            {
+                "assetId": 10024,
+                "symbol": "SN24",
+                "name": "SN24",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 24
+                }
+            },
+            {
+                "assetId": 10025,
+                "symbol": "SN25",
+                "name": "SN25",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 25
+                }
+            },
+            {
+                "assetId": 10026,
+                "symbol": "SN26",
+                "name": "SN26",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 26
+                }
+            },
+            {
+                "assetId": 10027,
+                "symbol": "SN27",
+                "name": "SN27",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 27
+                }
+            },
+            {
+                "assetId": 10028,
+                "symbol": "SN28",
+                "name": "SN28",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 28
+                }
+            },
+            {
+                "assetId": 10029,
+                "symbol": "SN29",
+                "name": "SN29",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 29
+                }
+            },
+            {
+                "assetId": 10030,
+                "symbol": "SN30",
+                "name": "SN30",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 30
+                }
+            },
+            {
+                "assetId": 10031,
+                "symbol": "SN31",
+                "name": "SN31",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 31
+                }
+            },
+            {
+                "assetId": 10032,
+                "symbol": "SN32",
+                "name": "SN32",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 32
+                }
+            },
+            {
+                "assetId": 10033,
+                "symbol": "SN33",
+                "name": "SN33",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 33
+                }
+            },
+            {
+                "assetId": 10034,
+                "symbol": "SN34",
+                "name": "SN34",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 34
+                }
+            },
+            {
+                "assetId": 10035,
+                "symbol": "SN35",
+                "name": "SN35",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 35
+                }
+            },
+            {
+                "assetId": 10036,
+                "symbol": "SN36",
+                "name": "SN36",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 36
+                }
+            },
+            {
+                "assetId": 10037,
+                "symbol": "SN37",
+                "name": "SN37",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 37
+                }
+            },
+            {
+                "assetId": 10038,
+                "symbol": "SN38",
+                "name": "SN38",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 38
+                }
+            },
+            {
+                "assetId": 10039,
+                "symbol": "SN39",
+                "name": "SN39",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 39
+                }
+            },
+            {
+                "assetId": 10040,
+                "symbol": "SN40",
+                "name": "SN40",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 40
+                }
+            },
+            {
+                "assetId": 10041,
+                "symbol": "SN41",
+                "name": "SN41",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 41
+                }
+            },
+            {
+                "assetId": 10042,
+                "symbol": "SN42",
+                "name": "SN42",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 42
+                }
+            },
+            {
+                "assetId": 10043,
+                "symbol": "SN43",
+                "name": "SN43",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 43
+                }
+            },
+            {
+                "assetId": 10044,
+                "symbol": "SN44",
+                "name": "SN44",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 44
+                }
+            },
+            {
+                "assetId": 10045,
+                "symbol": "SN45",
+                "name": "SN45",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 45
+                }
+            },
+            {
+                "assetId": 10046,
+                "symbol": "SN46",
+                "name": "SN46",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 46
+                }
+            },
+            {
+                "assetId": 10047,
+                "symbol": "SN47",
+                "name": "SN47",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 47
+                }
+            },
+            {
+                "assetId": 10048,
+                "symbol": "SN48",
+                "name": "SN48",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 48
+                }
+            },
+            {
+                "assetId": 10049,
+                "symbol": "SN49",
+                "name": "SN49",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 49
+                }
+            },
+            {
+                "assetId": 10050,
+                "symbol": "SN50",
+                "name": "SN50",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 50
+                }
+            },
+            {
+                "assetId": 10051,
+                "symbol": "SN51",
+                "name": "SN51",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 51
+                }
+            },
+            {
+                "assetId": 10052,
+                "symbol": "SN52",
+                "name": "SN52",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 52
+                }
+            },
+            {
+                "assetId": 10053,
+                "symbol": "SN53",
+                "name": "SN53",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 53
+                }
+            },
+            {
+                "assetId": 10054,
+                "symbol": "SN54",
+                "name": "SN54",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 54
+                }
+            },
+            {
+                "assetId": 10055,
+                "symbol": "SN55",
+                "name": "SN55",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 55
+                }
+            },
+            {
+                "assetId": 10056,
+                "symbol": "SN56",
+                "name": "SN56",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 56
+                }
+            },
+            {
+                "assetId": 10057,
+                "symbol": "SN57",
+                "name": "SN57",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 57
+                }
+            },
+            {
+                "assetId": 10058,
+                "symbol": "SN58",
+                "name": "SN58",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 58
+                }
+            },
+            {
+                "assetId": 10059,
+                "symbol": "SN59",
+                "name": "SN59",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 59
+                }
+            },
+            {
+                "assetId": 10060,
+                "symbol": "SN60",
+                "name": "SN60",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 60
+                }
+            },
+            {
+                "assetId": 10061,
+                "symbol": "SN61",
+                "name": "SN61",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 61
+                }
+            },
+            {
+                "assetId": 10062,
+                "symbol": "SN62",
+                "name": "SN62",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 62
+                }
+            },
+            {
+                "assetId": 10063,
+                "symbol": "SN63",
+                "name": "SN63",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 63
+                }
+            },
+            {
+                "assetId": 10064,
+                "symbol": "SN64",
+                "name": "SN64",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 64
+                }
+            },
+            {
+                "assetId": 10065,
+                "symbol": "SN65",
+                "name": "SN65",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 65
+                }
+            },
+            {
+                "assetId": 10066,
+                "symbol": "SN66",
+                "name": "SN66",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 66
+                }
+            },
+            {
+                "assetId": 10067,
+                "symbol": "SN67",
+                "name": "SN67",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 67
+                }
+            },
+            {
+                "assetId": 10068,
+                "symbol": "SN68",
+                "name": "SN68",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 68
+                }
+            },
+            {
+                "assetId": 10069,
+                "symbol": "SN69",
+                "name": "SN69",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 69
+                }
+            },
+            {
+                "assetId": 10070,
+                "symbol": "SN70",
+                "name": "SN70",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 70
+                }
+            },
+            {
+                "assetId": 10071,
+                "symbol": "SN71",
+                "name": "SN71",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 71
+                }
+            },
+            {
+                "assetId": 10072,
+                "symbol": "SN72",
+                "name": "SN72",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 72
+                }
+            },
+            {
+                "assetId": 10073,
+                "symbol": "SN73",
+                "name": "SN73",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 73
+                }
+            },
+            {
+                "assetId": 10074,
+                "symbol": "SN74",
+                "name": "SN74",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 74
+                }
+            },
+            {
+                "assetId": 10075,
+                "symbol": "SN75",
+                "name": "SN75",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 75
+                }
+            },
+            {
+                "assetId": 10076,
+                "symbol": "SN76",
+                "name": "SN76",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 76
+                }
+            },
+            {
+                "assetId": 10077,
+                "symbol": "SN77",
+                "name": "SN77",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 77
+                }
+            },
+            {
+                "assetId": 10078,
+                "symbol": "SN78",
+                "name": "SN78",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 78
+                }
+            },
+            {
+                "assetId": 10079,
+                "symbol": "SN79",
+                "name": "SN79",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 79
+                }
+            },
+            {
+                "assetId": 10080,
+                "symbol": "SN80",
+                "name": "SN80",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 80
+                }
+            },
+            {
+                "assetId": 10081,
+                "symbol": "SN81",
+                "name": "SN81",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 81
+                }
+            },
+            {
+                "assetId": 10082,
+                "symbol": "SN82",
+                "name": "SN82",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 82
+                }
+            },
+            {
+                "assetId": 10083,
+                "symbol": "SN83",
+                "name": "SN83",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 83
+                }
+            },
+            {
+                "assetId": 10084,
+                "symbol": "SN84",
+                "name": "SN84",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 84
+                }
+            },
+            {
+                "assetId": 10085,
+                "symbol": "SN85",
+                "name": "SN85",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 85
+                }
+            },
+            {
+                "assetId": 10086,
+                "symbol": "SN86",
+                "name": "SN86",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 86
+                }
+            },
+            {
+                "assetId": 10087,
+                "symbol": "SN87",
+                "name": "SN87",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 87
+                }
+            },
+            {
+                "assetId": 10088,
+                "symbol": "SN88",
+                "name": "SN88",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 88
+                }
+            },
+            {
+                "assetId": 10089,
+                "symbol": "SN89",
+                "name": "SN89",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 89
+                }
+            },
+            {
+                "assetId": 10090,
+                "symbol": "SN90",
+                "name": "SN90",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 90
+                }
+            },
+            {
+                "assetId": 10091,
+                "symbol": "SN91",
+                "name": "SN91",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 91
+                }
+            },
+            {
+                "assetId": 10092,
+                "symbol": "SN92",
+                "name": "SN92",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 92
+                }
+            },
+            {
+                "assetId": 10093,
+                "symbol": "SN93",
+                "name": "SN93",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 93
+                }
+            },
+            {
+                "assetId": 10094,
+                "symbol": "SN94",
+                "name": "SN94",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 94
+                }
+            },
+            {
+                "assetId": 10095,
+                "symbol": "SN95",
+                "name": "SN95",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 95
+                }
+            },
+            {
+                "assetId": 10096,
+                "symbol": "SN96",
+                "name": "SN96",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 96
+                }
+            },
+            {
+                "assetId": 10097,
+                "symbol": "SN97",
+                "name": "SN97",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 97
+                }
+            },
+            {
+                "assetId": 10098,
+                "symbol": "SN98",
+                "name": "SN98",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 98
+                }
+            },
+            {
+                "assetId": 10099,
+                "symbol": "SN99",
+                "name": "SN99",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 99
+                }
+            },
+            {
+                "assetId": 10100,
+                "symbol": "SN100",
+                "name": "SN100",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 100
+                }
+            },
+            {
+                "assetId": 10101,
+                "symbol": "SN101",
+                "name": "SN101",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 101
+                }
+            },
+            {
+                "assetId": 10102,
+                "symbol": "SN102",
+                "name": "SN102",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 102
+                }
+            },
+            {
+                "assetId": 10103,
+                "symbol": "SN103",
+                "name": "SN103",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 103
+                }
+            },
+            {
+                "assetId": 10104,
+                "symbol": "SN104",
+                "name": "SN104",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 104
+                }
+            },
+            {
+                "assetId": 10105,
+                "symbol": "SN105",
+                "name": "SN105",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 105
+                }
+            },
+            {
+                "assetId": 10106,
+                "symbol": "SN106",
+                "name": "SN106",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 106
+                }
+            },
+            {
+                "assetId": 10107,
+                "symbol": "SN107",
+                "name": "SN107",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 107
+                }
+            },
+            {
+                "assetId": 10108,
+                "symbol": "SN108",
+                "name": "SN108",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 108
+                }
+            },
+            {
+                "assetId": 10109,
+                "symbol": "SN109",
+                "name": "SN109",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 109
+                }
+            },
+            {
+                "assetId": 10110,
+                "symbol": "SN110",
+                "name": "SN110",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 110
+                }
+            },
+            {
+                "assetId": 10111,
+                "symbol": "SN111",
+                "name": "SN111",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 111
+                }
+            },
+            {
+                "assetId": 10112,
+                "symbol": "SN112",
+                "name": "SN112",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 112
+                }
+            },
+            {
+                "assetId": 10113,
+                "symbol": "SN113",
+                "name": "SN113",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 113
+                }
+            },
+            {
+                "assetId": 10114,
+                "symbol": "SN114",
+                "name": "SN114",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 114
+                }
+            },
+            {
+                "assetId": 10115,
+                "symbol": "SN115",
+                "name": "SN115",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 115
+                }
+            },
+            {
+                "assetId": 10116,
+                "symbol": "SN116",
+                "name": "SN116",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 116
+                }
+            },
+            {
+                "assetId": 10117,
+                "symbol": "SN117",
+                "name": "SN117",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 117
+                }
+            },
+            {
+                "assetId": 10118,
+                "symbol": "SN118",
+                "name": "SN118",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 118
+                }
+            },
+            {
+                "assetId": 10119,
+                "symbol": "SN119",
+                "name": "SN119",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 119
+                }
+            },
+            {
+                "assetId": 10120,
+                "symbol": "SN120",
+                "name": "SN120",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 120
+                }
+            },
+            {
+                "assetId": 10121,
+                "symbol": "SN121",
+                "name": "SN121",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 121
+                }
+            },
+            {
+                "assetId": 10122,
+                "symbol": "SN122",
+                "name": "SN122",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 122
+                }
+            },
+            {
+                "assetId": 10123,
+                "symbol": "SN123",
+                "name": "SN123",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 123
+                }
+            },
+            {
+                "assetId": 10124,
+                "symbol": "SN124",
+                "name": "SN124",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 124
+                }
+            },
+            {
+                "assetId": 10125,
+                "symbol": "SN125",
+                "name": "SN125",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 125
+                }
+            },
+            {
+                "assetId": 10126,
+                "symbol": "SN126",
+                "name": "SN126",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 126
+                }
+            },
+            {
+                "assetId": 10127,
+                "symbol": "SN127",
+                "name": "SN127",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 127
+                }
+            },
+            {
+                "assetId": 10128,
+                "symbol": "SN128",
+                "name": "SN128",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 128
+                }
             }
         ],
         "nodes": [

--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -8840,7 +8840,8 @@
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Bittensor.svg",
         "addressPrefix": 42,
         "additional": {
-            "supportsGenericLedgerApp": true
+            "supportsGenericLedgerApp": true,
+            "themeColor": "#F7CA47"
         }
     },
     {

--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -7010,7 +7010,10 @@
                 "symbol": "TAO",
                 "precision": 9,
                 "priceId": "bittensor",
-                "icon": "TAO_bittensor.svg"
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ]
             }
         ],
         "nodes": [

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -9844,7 +9844,8 @@
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Bittensor.svg",
         "addressPrefix": 42,
         "additional": {
-            "supportsGenericLedgerApp": true
+            "supportsGenericLedgerApp": true,
+            "themeColor": "#F7CA47"
         }
     },
     {

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -8014,7 +8014,10 @@
                 "symbol": "TAO",
                 "precision": 9,
                 "priceId": "bittensor",
-                "icon": "TAO_bittensor.svg"
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ]
             }
         ],
         "nodes": [

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -8018,6 +8018,1798 @@
                 "staking": [
                     "subtensor"
                 ]
+            },
+            {
+                "assetId": 10001,
+                "symbol": "SN1",
+                "name": "SN1",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 1
+                }
+            },
+            {
+                "assetId": 10002,
+                "symbol": "SN2",
+                "name": "SN2",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 2
+                }
+            },
+            {
+                "assetId": 10003,
+                "symbol": "SN3",
+                "name": "SN3",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 3
+                }
+            },
+            {
+                "assetId": 10004,
+                "symbol": "SN4",
+                "name": "SN4",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 4
+                }
+            },
+            {
+                "assetId": 10005,
+                "symbol": "SN5",
+                "name": "SN5",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 5
+                }
+            },
+            {
+                "assetId": 10006,
+                "symbol": "SN6",
+                "name": "SN6",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 6
+                }
+            },
+            {
+                "assetId": 10007,
+                "symbol": "SN7",
+                "name": "SN7",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 7
+                }
+            },
+            {
+                "assetId": 10008,
+                "symbol": "SN8",
+                "name": "SN8",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 8
+                }
+            },
+            {
+                "assetId": 10009,
+                "symbol": "SN9",
+                "name": "SN9",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 9
+                }
+            },
+            {
+                "assetId": 10010,
+                "symbol": "SN10",
+                "name": "SN10",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 10
+                }
+            },
+            {
+                "assetId": 10011,
+                "symbol": "SN11",
+                "name": "SN11",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 11
+                }
+            },
+            {
+                "assetId": 10012,
+                "symbol": "SN12",
+                "name": "SN12",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 12
+                }
+            },
+            {
+                "assetId": 10013,
+                "symbol": "SN13",
+                "name": "SN13",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 13
+                }
+            },
+            {
+                "assetId": 10014,
+                "symbol": "SN14",
+                "name": "SN14",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 14
+                }
+            },
+            {
+                "assetId": 10015,
+                "symbol": "SN15",
+                "name": "SN15",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 15
+                }
+            },
+            {
+                "assetId": 10016,
+                "symbol": "SN16",
+                "name": "SN16",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 16
+                }
+            },
+            {
+                "assetId": 10017,
+                "symbol": "SN17",
+                "name": "SN17",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 17
+                }
+            },
+            {
+                "assetId": 10018,
+                "symbol": "SN18",
+                "name": "SN18",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 18
+                }
+            },
+            {
+                "assetId": 10019,
+                "symbol": "SN19",
+                "name": "SN19",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 19
+                }
+            },
+            {
+                "assetId": 10020,
+                "symbol": "SN20",
+                "name": "SN20",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 20
+                }
+            },
+            {
+                "assetId": 10021,
+                "symbol": "SN21",
+                "name": "SN21",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 21
+                }
+            },
+            {
+                "assetId": 10022,
+                "symbol": "SN22",
+                "name": "SN22",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 22
+                }
+            },
+            {
+                "assetId": 10023,
+                "symbol": "SN23",
+                "name": "SN23",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 23
+                }
+            },
+            {
+                "assetId": 10024,
+                "symbol": "SN24",
+                "name": "SN24",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 24
+                }
+            },
+            {
+                "assetId": 10025,
+                "symbol": "SN25",
+                "name": "SN25",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 25
+                }
+            },
+            {
+                "assetId": 10026,
+                "symbol": "SN26",
+                "name": "SN26",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 26
+                }
+            },
+            {
+                "assetId": 10027,
+                "symbol": "SN27",
+                "name": "SN27",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 27
+                }
+            },
+            {
+                "assetId": 10028,
+                "symbol": "SN28",
+                "name": "SN28",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 28
+                }
+            },
+            {
+                "assetId": 10029,
+                "symbol": "SN29",
+                "name": "SN29",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 29
+                }
+            },
+            {
+                "assetId": 10030,
+                "symbol": "SN30",
+                "name": "SN30",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 30
+                }
+            },
+            {
+                "assetId": 10031,
+                "symbol": "SN31",
+                "name": "SN31",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 31
+                }
+            },
+            {
+                "assetId": 10032,
+                "symbol": "SN32",
+                "name": "SN32",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 32
+                }
+            },
+            {
+                "assetId": 10033,
+                "symbol": "SN33",
+                "name": "SN33",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 33
+                }
+            },
+            {
+                "assetId": 10034,
+                "symbol": "SN34",
+                "name": "SN34",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 34
+                }
+            },
+            {
+                "assetId": 10035,
+                "symbol": "SN35",
+                "name": "SN35",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 35
+                }
+            },
+            {
+                "assetId": 10036,
+                "symbol": "SN36",
+                "name": "SN36",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 36
+                }
+            },
+            {
+                "assetId": 10037,
+                "symbol": "SN37",
+                "name": "SN37",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 37
+                }
+            },
+            {
+                "assetId": 10038,
+                "symbol": "SN38",
+                "name": "SN38",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 38
+                }
+            },
+            {
+                "assetId": 10039,
+                "symbol": "SN39",
+                "name": "SN39",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 39
+                }
+            },
+            {
+                "assetId": 10040,
+                "symbol": "SN40",
+                "name": "SN40",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 40
+                }
+            },
+            {
+                "assetId": 10041,
+                "symbol": "SN41",
+                "name": "SN41",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 41
+                }
+            },
+            {
+                "assetId": 10042,
+                "symbol": "SN42",
+                "name": "SN42",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 42
+                }
+            },
+            {
+                "assetId": 10043,
+                "symbol": "SN43",
+                "name": "SN43",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 43
+                }
+            },
+            {
+                "assetId": 10044,
+                "symbol": "SN44",
+                "name": "SN44",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 44
+                }
+            },
+            {
+                "assetId": 10045,
+                "symbol": "SN45",
+                "name": "SN45",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 45
+                }
+            },
+            {
+                "assetId": 10046,
+                "symbol": "SN46",
+                "name": "SN46",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 46
+                }
+            },
+            {
+                "assetId": 10047,
+                "symbol": "SN47",
+                "name": "SN47",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 47
+                }
+            },
+            {
+                "assetId": 10048,
+                "symbol": "SN48",
+                "name": "SN48",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 48
+                }
+            },
+            {
+                "assetId": 10049,
+                "symbol": "SN49",
+                "name": "SN49",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 49
+                }
+            },
+            {
+                "assetId": 10050,
+                "symbol": "SN50",
+                "name": "SN50",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 50
+                }
+            },
+            {
+                "assetId": 10051,
+                "symbol": "SN51",
+                "name": "SN51",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 51
+                }
+            },
+            {
+                "assetId": 10052,
+                "symbol": "SN52",
+                "name": "SN52",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 52
+                }
+            },
+            {
+                "assetId": 10053,
+                "symbol": "SN53",
+                "name": "SN53",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 53
+                }
+            },
+            {
+                "assetId": 10054,
+                "symbol": "SN54",
+                "name": "SN54",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 54
+                }
+            },
+            {
+                "assetId": 10055,
+                "symbol": "SN55",
+                "name": "SN55",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 55
+                }
+            },
+            {
+                "assetId": 10056,
+                "symbol": "SN56",
+                "name": "SN56",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 56
+                }
+            },
+            {
+                "assetId": 10057,
+                "symbol": "SN57",
+                "name": "SN57",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 57
+                }
+            },
+            {
+                "assetId": 10058,
+                "symbol": "SN58",
+                "name": "SN58",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 58
+                }
+            },
+            {
+                "assetId": 10059,
+                "symbol": "SN59",
+                "name": "SN59",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 59
+                }
+            },
+            {
+                "assetId": 10060,
+                "symbol": "SN60",
+                "name": "SN60",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 60
+                }
+            },
+            {
+                "assetId": 10061,
+                "symbol": "SN61",
+                "name": "SN61",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 61
+                }
+            },
+            {
+                "assetId": 10062,
+                "symbol": "SN62",
+                "name": "SN62",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 62
+                }
+            },
+            {
+                "assetId": 10063,
+                "symbol": "SN63",
+                "name": "SN63",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 63
+                }
+            },
+            {
+                "assetId": 10064,
+                "symbol": "SN64",
+                "name": "SN64",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 64
+                }
+            },
+            {
+                "assetId": 10065,
+                "symbol": "SN65",
+                "name": "SN65",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 65
+                }
+            },
+            {
+                "assetId": 10066,
+                "symbol": "SN66",
+                "name": "SN66",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 66
+                }
+            },
+            {
+                "assetId": 10067,
+                "symbol": "SN67",
+                "name": "SN67",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 67
+                }
+            },
+            {
+                "assetId": 10068,
+                "symbol": "SN68",
+                "name": "SN68",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 68
+                }
+            },
+            {
+                "assetId": 10069,
+                "symbol": "SN69",
+                "name": "SN69",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 69
+                }
+            },
+            {
+                "assetId": 10070,
+                "symbol": "SN70",
+                "name": "SN70",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 70
+                }
+            },
+            {
+                "assetId": 10071,
+                "symbol": "SN71",
+                "name": "SN71",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 71
+                }
+            },
+            {
+                "assetId": 10072,
+                "symbol": "SN72",
+                "name": "SN72",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 72
+                }
+            },
+            {
+                "assetId": 10073,
+                "symbol": "SN73",
+                "name": "SN73",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 73
+                }
+            },
+            {
+                "assetId": 10074,
+                "symbol": "SN74",
+                "name": "SN74",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 74
+                }
+            },
+            {
+                "assetId": 10075,
+                "symbol": "SN75",
+                "name": "SN75",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 75
+                }
+            },
+            {
+                "assetId": 10076,
+                "symbol": "SN76",
+                "name": "SN76",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 76
+                }
+            },
+            {
+                "assetId": 10077,
+                "symbol": "SN77",
+                "name": "SN77",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 77
+                }
+            },
+            {
+                "assetId": 10078,
+                "symbol": "SN78",
+                "name": "SN78",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 78
+                }
+            },
+            {
+                "assetId": 10079,
+                "symbol": "SN79",
+                "name": "SN79",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 79
+                }
+            },
+            {
+                "assetId": 10080,
+                "symbol": "SN80",
+                "name": "SN80",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 80
+                }
+            },
+            {
+                "assetId": 10081,
+                "symbol": "SN81",
+                "name": "SN81",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 81
+                }
+            },
+            {
+                "assetId": 10082,
+                "symbol": "SN82",
+                "name": "SN82",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 82
+                }
+            },
+            {
+                "assetId": 10083,
+                "symbol": "SN83",
+                "name": "SN83",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 83
+                }
+            },
+            {
+                "assetId": 10084,
+                "symbol": "SN84",
+                "name": "SN84",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 84
+                }
+            },
+            {
+                "assetId": 10085,
+                "symbol": "SN85",
+                "name": "SN85",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 85
+                }
+            },
+            {
+                "assetId": 10086,
+                "symbol": "SN86",
+                "name": "SN86",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 86
+                }
+            },
+            {
+                "assetId": 10087,
+                "symbol": "SN87",
+                "name": "SN87",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 87
+                }
+            },
+            {
+                "assetId": 10088,
+                "symbol": "SN88",
+                "name": "SN88",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 88
+                }
+            },
+            {
+                "assetId": 10089,
+                "symbol": "SN89",
+                "name": "SN89",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 89
+                }
+            },
+            {
+                "assetId": 10090,
+                "symbol": "SN90",
+                "name": "SN90",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 90
+                }
+            },
+            {
+                "assetId": 10091,
+                "symbol": "SN91",
+                "name": "SN91",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 91
+                }
+            },
+            {
+                "assetId": 10092,
+                "symbol": "SN92",
+                "name": "SN92",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 92
+                }
+            },
+            {
+                "assetId": 10093,
+                "symbol": "SN93",
+                "name": "SN93",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 93
+                }
+            },
+            {
+                "assetId": 10094,
+                "symbol": "SN94",
+                "name": "SN94",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 94
+                }
+            },
+            {
+                "assetId": 10095,
+                "symbol": "SN95",
+                "name": "SN95",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 95
+                }
+            },
+            {
+                "assetId": 10096,
+                "symbol": "SN96",
+                "name": "SN96",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 96
+                }
+            },
+            {
+                "assetId": 10097,
+                "symbol": "SN97",
+                "name": "SN97",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 97
+                }
+            },
+            {
+                "assetId": 10098,
+                "symbol": "SN98",
+                "name": "SN98",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 98
+                }
+            },
+            {
+                "assetId": 10099,
+                "symbol": "SN99",
+                "name": "SN99",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 99
+                }
+            },
+            {
+                "assetId": 10100,
+                "symbol": "SN100",
+                "name": "SN100",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 100
+                }
+            },
+            {
+                "assetId": 10101,
+                "symbol": "SN101",
+                "name": "SN101",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 101
+                }
+            },
+            {
+                "assetId": 10102,
+                "symbol": "SN102",
+                "name": "SN102",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 102
+                }
+            },
+            {
+                "assetId": 10103,
+                "symbol": "SN103",
+                "name": "SN103",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 103
+                }
+            },
+            {
+                "assetId": 10104,
+                "symbol": "SN104",
+                "name": "SN104",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 104
+                }
+            },
+            {
+                "assetId": 10105,
+                "symbol": "SN105",
+                "name": "SN105",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 105
+                }
+            },
+            {
+                "assetId": 10106,
+                "symbol": "SN106",
+                "name": "SN106",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 106
+                }
+            },
+            {
+                "assetId": 10107,
+                "symbol": "SN107",
+                "name": "SN107",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 107
+                }
+            },
+            {
+                "assetId": 10108,
+                "symbol": "SN108",
+                "name": "SN108",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 108
+                }
+            },
+            {
+                "assetId": 10109,
+                "symbol": "SN109",
+                "name": "SN109",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 109
+                }
+            },
+            {
+                "assetId": 10110,
+                "symbol": "SN110",
+                "name": "SN110",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 110
+                }
+            },
+            {
+                "assetId": 10111,
+                "symbol": "SN111",
+                "name": "SN111",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 111
+                }
+            },
+            {
+                "assetId": 10112,
+                "symbol": "SN112",
+                "name": "SN112",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 112
+                }
+            },
+            {
+                "assetId": 10113,
+                "symbol": "SN113",
+                "name": "SN113",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 113
+                }
+            },
+            {
+                "assetId": 10114,
+                "symbol": "SN114",
+                "name": "SN114",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 114
+                }
+            },
+            {
+                "assetId": 10115,
+                "symbol": "SN115",
+                "name": "SN115",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 115
+                }
+            },
+            {
+                "assetId": 10116,
+                "symbol": "SN116",
+                "name": "SN116",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 116
+                }
+            },
+            {
+                "assetId": 10117,
+                "symbol": "SN117",
+                "name": "SN117",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 117
+                }
+            },
+            {
+                "assetId": 10118,
+                "symbol": "SN118",
+                "name": "SN118",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 118
+                }
+            },
+            {
+                "assetId": 10119,
+                "symbol": "SN119",
+                "name": "SN119",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 119
+                }
+            },
+            {
+                "assetId": 10120,
+                "symbol": "SN120",
+                "name": "SN120",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 120
+                }
+            },
+            {
+                "assetId": 10121,
+                "symbol": "SN121",
+                "name": "SN121",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 121
+                }
+            },
+            {
+                "assetId": 10122,
+                "symbol": "SN122",
+                "name": "SN122",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 122
+                }
+            },
+            {
+                "assetId": 10123,
+                "symbol": "SN123",
+                "name": "SN123",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 123
+                }
+            },
+            {
+                "assetId": 10124,
+                "symbol": "SN124",
+                "name": "SN124",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 124
+                }
+            },
+            {
+                "assetId": 10125,
+                "symbol": "SN125",
+                "name": "SN125",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 125
+                }
+            },
+            {
+                "assetId": 10126,
+                "symbol": "SN126",
+                "name": "SN126",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 126
+                }
+            },
+            {
+                "assetId": 10127,
+                "symbol": "SN127",
+                "name": "SN127",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 127
+                }
+            },
+            {
+                "assetId": 10128,
+                "symbol": "SN128",
+                "name": "SN128",
+                "precision": 9,
+                "icon": "TAO_bittensor.svg",
+                "staking": [
+                    "subtensor"
+                ],
+                "type": "subtensor-alpha",
+                "typeExtras": {
+                    "netuid": 128
+                }
             }
         ],
         "nodes": [


### PR DESCRIPTION
## Summary

Enables Bittensor (TAO) staking in Nova clients via two changes to `chains/v22/chains.json` + `chains/v22/chains_dev.json`:

1. **TAO native asset** advertises `"staking": ["subtensor"]`. The Bittensor chain gets `additional.themeColor = "#F7CA47"` (gold) for the Start Staking Info screen.
2. **128 subnet-alpha assets** declared one per netuid (1–128):
   ```
   { assetId: 10000 + netuid, symbol: "SN{N}", name: "SN{N}", precision: 9,
     icon: "TAO_bittensor.svg", staking: ["subtensor"], type: "subtensor-alpha",
     typeExtras: { netuid: N } }
   ```

## Why

Required by the iOS and Android TAO staking PRs:

- iOS: novasamatech/nova-wallet-ios#1831
- Android: novasamatech/nova-wallet-android#2283

Without this, the staking tile on Bittensor only appears in DEBUG builds via a local `chains_dev_subtensor.json` server. Merging unblocks the production rollout.

## Notes

- Names ship as `SN{N}` placeholders — most subnets don't have a real name set on-chain (`SubnetIdentitiesV3(netuid)` is unset for the majority). Clients can layer a runtime override on top — separate follow-up.
- All 128 subnet icons reuse `TAO_bittensor.svg`; per-subnet icons are a design follow-up.
- `"subtensor"` and `"subtensor-alpha"` are unknown to older clients and are ignored gracefully — no regression on existing wallets.
