### PR TITLE
Energy Web X: parachain-avn staking type + theme colour

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -7741,7 +7741,10 @@
                 "symbol": "EWT",
                 "priceId": "energy-web-token",
                 "precision": 18,
-                "icon": "EWT.svg"
+                "icon": "EWT.svg",
+                "staking": [
+                    "parachain-avn"
+                ]
             }
         ],
         "nodes": [
@@ -7766,7 +7769,10 @@
             ]
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Energy_Web_X.svg",
-        "addressPrefix": 42
+        "addressPrefix": 42,
+        "additional": {
+            "themeColor": "#A566FF"
+        }
     },
     {
         "chainId": "31a7d8914fb31c249b972f18c115f1e22b4b039abbcb03c73b6774c5642f9efe",

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -9641,7 +9641,10 @@
                 "symbol": "EWT",
                 "priceId": "energy-web-token",
                 "precision": 18,
-                "icon": "EWT.svg"
+                "icon": "EWT.svg",
+                "staking": [
+                    "parachain-avn"
+                ]
             }
         ],
         "nodes": [
@@ -9668,7 +9671,8 @@
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Energy_Web_X.svg",
         "addressPrefix": 42,
         "additional": {
-            "supportsGenericLedgerApp": true
+            "supportsGenericLedgerApp": true,
+            "themeColor": "#A566FF"
         }
     },
     {


### PR DESCRIPTION
## Summary

Enables EWT staking in Nova clients via two changes to the EWX chain entry in `chains/v22/chains.json` + `chains/v22/chains_dev.json`:

1. **EWT asset** advertises `"staking": ["parachain-avn"]` — the AvN-fork variant of `pallet-parachain-staking` (pre-Moonbeam-rename call names like `nominate` / `scheduleNominatorUnbond`, different storage keys like `NominatorState` vs `DelegatorState`). A dedicated staking type is used rather than reusing `"parachain"` because the call surface and storage keys differ from Moonbeam.
2. **EWX chain** gets `additional.themeColor = "#A566FF"` (purple) for the Start Staking Info screen and dashboard tile.

## Why

Required by the iOS and Android EWT staking PRs:

- iOS: novasamatech/nova-wallet-ios#1832
- Android: novasamatech/nova-wallet-android#2284

Without this, both clients carry `[TEMP-QA-HACK]` overrides that inject the staking type + theme colour at decode time on a hardcoded EWX chain id. Merging lets both override blocks (iOS `AssetModel+Remote.swift`, Android `RemoteToLocalChainMappers` + `LocalToDomainChainMapper`) be removed.

## Notes

- Additive JSON change — other chain entries untouched.
- `"parachain-avn"` is unknown to older clients and is ignored gracefully — no regression on existing wallets.
