### PR TITLE
fix: add more nodes to the config

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -51,6 +51,26 @@
             {
                 "url": "wss://rpc-polkadot.luckyfriday.io",
                 "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://polkadot-rpc.publicnode.com",
+                "name": "Allnodes node"
+            },
+            {
+                "url": "wss://polkadot-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc-polkadot.helixstreet.io",
+                "name": "Helixstreet node"
+            },
+            {
+                "url": "wss://polkadot.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
+            },
+            {
+                "url": "wss://rpc-polkadot.stakeworld.io",
+                "name": "Stakeworld node"
             }
         ],
         "explorers": [
@@ -169,6 +189,26 @@
             {
                 "url": "wss://kusama.public.curie.radiumblock.co/ws",
                 "name": "Radium node"
+            },
+            {
+                "url": "wss://kusama-rpc.publicnode.com",
+                "name": "Allnodes node"
+            },
+            {
+                "url": "wss://kusama-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc-kusama.helixstreet.io",
+                "name": "Helixstreet node"
+            },
+            {
+                "url": "wss://kusama.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
+            },
+            {
+                "url": "wss://rpc-kusama.stakeworld.io",
+                "name": "Stakeworld node"
             }
         ],
         "explorers": [
@@ -261,6 +301,10 @@
             {
                 "url": "wss://westend.public.curie.radiumblock.co/ws",
                 "name": "RadiumBlock node"
+            },
+            {
+                "url": "wss://westend-rpc.n.dwellir.com",
+                "name": "Dwellir node"
             }
         ],
         "explorers": [
@@ -435,6 +479,10 @@
             {
                 "url": "wss://asset-hub-kusama.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://assethub-kusama.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -553,6 +601,14 @@
             {
                 "url": "wss://people-polkadot.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://people-polkadot-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://people-polkadot.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -614,6 +670,18 @@
             {
                 "url": "wss://people-kusama.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://people-kusama-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc-people-kusama.luckyfriday.io",
+                "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://people-kusama.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -1337,6 +1405,18 @@
             {
                 "url": "wss://moonbeam.public.curie.radiumblock.co/ws",
                 "name": "RadiumBlock node"
+            },
+            {
+                "url": "wss://moonbeam-rpc.publicnode.com",
+                "name": "Allnodes node"
+            },
+            {
+                "url": "wss://moonbeam-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://moonbeam.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -1768,6 +1848,14 @@
             {
                 "url": "wss://moonriver.public.curie.radiumblock.co/ws",
                 "name": "RadiumBlock node"
+            },
+            {
+                "url": "wss://moonriver-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://moonriver.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -2004,6 +2092,10 @@
             {
                 "url": "wss://shiden.public.curie.radiumblock.co/ws",
                 "name": "RadiumBlock node"
+            },
+            {
+                "url": "wss://shiden.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -3013,6 +3105,10 @@
             {
                 "url": "wss://astar.public.curie.radiumblock.co/ws",
                 "name": "RadiumBlock node"
+            },
+            {
+                "url": "wss://astar.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -3371,6 +3467,14 @@
             {
                 "url": "wss://asset-hub-polkadot.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://rpc-asset-hub-polkadot.luckyfriday.io",
+                "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://polkadot-asset-hub-rpc.polkadot.io",
+                "name": "Parity node"
             }
         ],
         "explorers": [
@@ -3537,6 +3641,18 @@
             {
                 "url": "wss://encointer-kusama.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://encointer-kusama-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://kusama.api.encointer.org",
+                "name": "Encointer node"
+            },
+            {
+                "url": "wss://rpc-encointer-kusama.luckyfriday.io",
+                "name": "LuckyFriday node"
             }
         ],
         "explorers": [
@@ -4029,6 +4145,10 @@
             {
                 "url": "wss://rpc-centrifuge.luckyfriday.io",
                 "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://centrifuge-parachain.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -5990,6 +6110,10 @@
             {
                 "url": "wss://heima-rpc.n.dwellir.com",
                 "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc.heima-parachain.heima.network",
+                "name": "Heima node"
             }
         ],
         "explorers": [
@@ -7284,6 +7408,10 @@
             {
                 "url": "wss://1.rpc.frequency.xyz",
                 "name": "Frequency1 node"
+            },
+            {
+                "url": "wss://frequency-polkadot.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "externalApi": {
@@ -7436,6 +7564,22 @@
             {
                 "url": "wss://bridge-hub-polkadot.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://bridge-hub-polkadot-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc-bridge-hub-polkadot.luckyfriday.io",
+                "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://bridgehub-polkadot.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
+            },
+            {
+                "url": "wss://polkadot-bridge-hub-rpc.polkadot.io",
+                "name": "Parity node"
             }
         ],
         "explorers": [
@@ -7494,6 +7638,22 @@
             {
                 "url": "wss://bridge-hub-kusama.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://bridge-hub-kusama-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc-bridge-hub-kusama.luckyfriday.io",
+                "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://bridgehub-kusama.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
+            },
+            {
+                "url": "wss://kusama-bridge-hub-rpc.polkadot.io",
+                "name": "Parity node"
             }
         ],
         "explorers": [
@@ -7556,6 +7716,22 @@
             {
                 "url": "wss://collectives-polkadot.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://collectives-polkadot-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc-collectives-polkadot.luckyfriday.io",
+                "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://collectives.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
+            },
+            {
+                "url": "wss://polkadot-collectives-rpc.polkadot.io",
+                "name": "Parity node"
             }
         ],
         "explorers": [
@@ -7670,6 +7846,10 @@
             {
                 "url": "wss://rpc.joystream.org",
                 "name": "Jsgenesis node"
+            },
+            {
+                "url": "wss://rpc.l1.media",
+                "name": "l1.media node"
             }
         ],
         "explorers": [
@@ -8890,6 +9070,14 @@
             {
                 "url": "wss://coretime-polkadot.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://coretime-polkadot-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://coretime-polkadot.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -8952,6 +9140,14 @@
             {
                 "url": "wss://coretime-kusama.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://coretime-kusama-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://coretime-kusama.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -51,6 +51,26 @@
             {
                 "url": "wss://rpc-polkadot.luckyfriday.io",
                 "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://polkadot-rpc.publicnode.com",
+                "name": "Allnodes node"
+            },
+            {
+                "url": "wss://polkadot-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc-polkadot.helixstreet.io",
+                "name": "Helixstreet node"
+            },
+            {
+                "url": "wss://polkadot.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
+            },
+            {
+                "url": "wss://rpc-polkadot.stakeworld.io",
+                "name": "Stakeworld node"
             }
         ],
         "explorers": [
@@ -183,6 +203,26 @@
             {
                 "url": "wss://kusama.public.curie.radiumblock.co/ws",
                 "name": "Radium node"
+            },
+            {
+                "url": "wss://kusama-rpc.publicnode.com",
+                "name": "Allnodes node"
+            },
+            {
+                "url": "wss://kusama-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc-kusama.helixstreet.io",
+                "name": "Helixstreet node"
+            },
+            {
+                "url": "wss://kusama.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
+            },
+            {
+                "url": "wss://rpc-kusama.stakeworld.io",
+                "name": "Stakeworld node"
             }
         ],
         "explorers": [
@@ -281,6 +321,10 @@
             {
                 "url": "wss://westend.public.curie.radiumblock.co/ws",
                 "name": "RadiumBlock node"
+            },
+            {
+                "url": "wss://westend-rpc.n.dwellir.com",
+                "name": "Dwellir node"
             }
         ],
         "explorers": [
@@ -374,6 +418,10 @@
             {
                 "url": "wss://asset-hub-westend.rpc.permanence.io",
                 "name": "Permanence DAO EU"
+            },
+            {
+                "url": "wss://asset-hub-westend-rpc.n.dwellir.com",
+                "name": "Dwellir node"
             }
         ],
         "explorers": [
@@ -558,6 +606,10 @@
             {
                 "url": "wss://asset-hub-kusama.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://assethub-kusama.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -1322,6 +1374,14 @@
             {
                 "url": "wss://moonriver.public.curie.radiumblock.co/ws",
                 "name": "RadiumBlock node"
+            },
+            {
+                "url": "wss://moonriver-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://moonriver.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -1428,6 +1488,14 @@
             {
                 "url": "wss://wss.api.moonbase.moonbeam.network",
                 "name": "Moonbase node"
+            },
+            {
+                "url": "wss://moonbase-alpha-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://moonbeam-alpha.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -1618,6 +1686,10 @@
             {
                 "url": "wss://shiden.public.curie.radiumblock.co/ws",
                 "name": "RadiumBlock node"
+            },
+            {
+                "url": "wss://shiden.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -3030,6 +3102,18 @@
             {
                 "url": "wss://moonbeam.public.curie.radiumblock.co/ws",
                 "name": "RadiumBlock node"
+            },
+            {
+                "url": "wss://moonbeam-rpc.publicnode.com",
+                "name": "Allnodes node"
+            },
+            {
+                "url": "wss://moonbeam-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://moonbeam.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -3452,6 +3536,14 @@
             {
                 "url": "wss://astar.public.curie.radiumblock.co/ws",
                 "name": "RadiumBlock node"
+            },
+            {
+                "url": "wss://astar-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://astar.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -3826,6 +3918,14 @@
             {
                 "url": "wss://asset-hub-polkadot.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://rpc-asset-hub-polkadot.luckyfriday.io",
+                "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://polkadot-asset-hub-rpc.polkadot.io",
+                "name": "Parity node"
             }
         ],
         "explorers": [
@@ -4004,6 +4104,18 @@
             {
                 "url": "wss://encointer-kusama.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://encointer-kusama-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://kusama.api.encointer.org",
+                "name": "Encointer node"
+            },
+            {
+                "url": "wss://rpc-encointer-kusama.luckyfriday.io",
+                "name": "LuckyFriday node"
             }
         ],
         "explorers": [
@@ -4331,6 +4443,10 @@
             {
                 "url": "wss://rpc-centrifuge.luckyfriday.io",
                 "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://centrifuge-parachain.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -6429,6 +6545,10 @@
             {
                 "url": "wss://heima-rpc.n.dwellir.com",
                 "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc.heima-parachain.heima.network",
+                "name": "Heima node"
             }
         ],
         "explorers": [
@@ -8375,6 +8495,10 @@
             {
                 "url": "wss://1.rpc.frequency.xyz",
                 "name": "Frequency1 node"
+            },
+            {
+                "url": "wss://frequency-polkadot.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "externalApi": {
@@ -8718,6 +8842,22 @@
             {
                 "url": "wss://bridge-hub-polkadot.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://bridge-hub-polkadot-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc-bridge-hub-polkadot.luckyfriday.io",
+                "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://bridgehub-polkadot.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
+            },
+            {
+                "url": "wss://polkadot-bridge-hub-rpc.polkadot.io",
+                "name": "Parity node"
             }
         ],
         "explorers": [
@@ -8777,6 +8917,22 @@
             {
                 "url": "wss://bridge-hub-kusama.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://bridge-hub-kusama-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc-bridge-hub-kusama.luckyfriday.io",
+                "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://bridgehub-kusama.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
+            },
+            {
+                "url": "wss://kusama-bridge-hub-rpc.polkadot.io",
+                "name": "Parity node"
             }
         ],
         "explorers": [
@@ -8840,6 +8996,22 @@
             {
                 "url": "wss://collectives-polkadot.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://collectives-polkadot-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc-collectives-polkadot.luckyfriday.io",
+                "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://collectives.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
+            },
+            {
+                "url": "wss://polkadot-collectives-rpc.polkadot.io",
+                "name": "Parity node"
             }
         ],
         "explorers": [
@@ -8910,6 +9082,14 @@
             {
                 "url": "wss://people-polkadot.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://people-polkadot-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://people-polkadot.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -8971,6 +9151,18 @@
             {
                 "url": "wss://people-kusama.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://people-kusama-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc-people-kusama.luckyfriday.io",
+                "name": "LuckyFriday node"
+            },
+            {
+                "url": "wss://people-kusama.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -9485,6 +9677,14 @@
             {
                 "url": "https://astar-rpc.dwellir.com",
                 "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc.astar.network",
+                "name": "Astar node"
+            },
+            {
+                "url": "wss://astar.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -9612,6 +9812,10 @@
             {
                 "url": "wss://rpc.joystream.org",
                 "name": "Jsgenesis node"
+            },
+            {
+                "url": "wss://rpc.l1.media",
+                "name": "l1.media node"
             }
         ],
         "explorers": [
@@ -9798,6 +10002,22 @@
             {
                 "url": "wss://crust-mainnet-rpc.dwellir.com",
                 "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc.crustnetwork.app",
+                "name": "Crust Network APP node"
+            },
+            {
+                "url": "wss://rpc.crustnetwork.cc",
+                "name": "Crust Network CC node"
+            },
+            {
+                "url": "wss://rpc.crustnetwork.xyz",
+                "name": "Crust Network XYZ node"
+            },
+            {
+                "url": "wss://crust.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -9900,6 +10120,10 @@
             {
                 "url": "wss://westend-bridge-hub-rpc.polkadot.io",
                 "name": "Parity node"
+            },
+            {
+                "url": "wss://bridge-hub-westend-rpc.n.dwellir.com",
+                "name": "Dwellir node"
             }
         ],
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/BridgeHub_Testnet.svg",
@@ -10997,6 +11221,10 @@
             {
                 "url": "wss://westend-collectives-rpc.polkadot.io",
                 "name": "Parity node"
+            },
+            {
+                "url": "wss://collectives-westend-rpc.n.dwellir.com",
+                "name": "Dwellir node"
             }
         ],
         "explorers": [
@@ -11131,6 +11359,14 @@
             {
                 "url": "wss://coretime-polkadot.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://coretime-polkadot-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://coretime-polkadot.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -11193,6 +11429,14 @@
             {
                 "url": "wss://coretime-kusama.rotko.net",
                 "name": "Rotko node"
+            },
+            {
+                "url": "wss://coretime-kusama-rpc.n.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
+                "url": "wss://coretime-kusama.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [


### PR DESCRIPTION
## What

Adds public RPC nodes from polkadot-js to the v22 config: **62 unique endpoints**, appearing as 110 entries across `chains.json` and `chains_dev.json`.

Rebuilt on top of current master. The branch was opened in May and had drifted badly, so rather than rebasing it I re-validated every endpoint and kept only the ones that still work.

## What was dropped and why

Of the 109 (network, url) pairs the original branch added, **40 were dead** and 2 more were actively wrong:

| dropped | count | reason |
|---|---|---|
| `ibp.network` | 13 | the domain no longer resolves — `NXDOMAIN` for the subdomains, `SERVFAIL` at the `dotters.network` apex. #4368 removes the ones already in the config |
| radiumblock | 7 | Cloudflare returns 522/530, i.e. it cannot reach their origin |
| crustnetwork (shadow / parachain) | 6 | unreachable |
| onfinality | 4 | subdomains removed |
| subquery, unitedbloc | 4 | host does not resolve |
| helikon, helixstreet, joyutils, dwellir | 4 | unreachable |
| **Xode** | **2** | see below |

### The Xode nodes are the interesting one

`wss://rakson-rpc.xode.net` and `wss://rakson-ceb-rpc.xode.net` answer, produce blocks, and report `system_chain: "Xode"` — they look perfectly healthy. But their genesis is `b2985e778bb748c7…` while the config entry's chainId is `28cc1df52619f4ed…`. Xode relaunched with a new genesis, so these serve a *different chain* than the one they would have been attached to.

That is worse than a dead endpoint: a wallet would connect successfully and be on the wrong network. Xode needs a new entry with the new chainId, not extra nodes on the old one — it is currently `Xode (PAUSED)` in master.

## Verification

Every one of the 62 kept endpoints was re-probed after the rebuild:

- connects over WSS
- `chain_getBlockHash(0)` matches the configured `chainId` exactly
- for the EVM entries (`eip155:*`), `eth_chainId` matches instead — this is why the Astar EVM additions are correct even though a genesis comparison would fail for them

62/62 passed, zero failures.

## Networks gaining nodes

```
Astar                          +3   Moonbeam (PAUSED)              +6
Astar EVM                      +2   Moonriver (PAUSED)             +4
Centrifuge Parachain           +2   Polkadot Asset Hub             +4
Crust                          +4   Polkadot Bridge Hub            +8
Encointer                      +6   Polkadot Collectives           +8
Frequency                      +2   Polkadot Coretime              +4
Heima                          +2   Polkadot People                +4
Joystream                      +2   Polkadot Relay                 +10
Kusama Asset Hub               +2   Shiden                         +2
Kusama Bridge Hub              +8   Westend                        +1
Kusama Coretime                +4   Westend (TESTNET)              +1
Kusama People                  +6   Westend Asset Hub (TESTNET)    +1
Kusama Relay                   +10   Westend Bridge Hub             +1
Moonbase Alpha                 +2   Westend Collectives            +1
```

Counts are entries, so a network present in both configs shows twice its unique endpoints.

## Worth a reviewer's attention

- **Moonbeam and Moonriver are `(PAUSED)` in master** and still receive nodes here (3 and 2 unique endpoints). They were verified working, and both networks responded during the audit, so the nodes are correct — but if you would rather not touch paused entries, say so and I will strip them.
- **Joystream gets `wss://rpc.l1.media`**, which matters beyond this PR: its only configured node (`rpc.joystream.org`) no longer resolves, which is why #4369 originally proposed pausing Joystream. This endpoint works — genesis matches, 17 peers, head advancing — so Joystream has been dropped from that pause list. **Merge this before #4369** so Joystream is never left un-paused with no working node.

## Related

- #4368 removes the dead `ibp.network` / `dotters.network` nodes this PR deliberately no longer adds
- #4369 pauses networks that produce no blocks; Joystream was removed from it because of the endpoint above
