### PR TITLE
Update Hydration Subscan URL

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -5078,8 +5078,8 @@
         "explorers": [
             {
                 "name": "Subscan",
-                "extrinsic": "https://hydradx.subscan.io/extrinsic/{hash}",
-                "account": "https://hydradx.subscan.io/account/{address}"
+                "extrinsic": "https://hydration.subscan.io/extrinsic/{hash}",
+                "account": "https://hydration.subscan.io/account/{address}"
             }
         ],
         "externalApi": {

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -5388,8 +5388,8 @@
         "explorers": [
             {
                 "name": "Subscan",
-                "extrinsic": "https://hydradx.subscan.io/extrinsic/{hash}",
-                "account": "https://hydradx.subscan.io/account/{address}"
+                "extrinsic": "https://hydration.subscan.io/extrinsic/{hash}",
+                "account": "https://hydration.subscan.io/account/{address}"
             }
         ],
         "externalApi": {


### PR DESCRIPTION
Updated Hydration Subscan URL as old hydradx.subscan.io link no longer works.