### PR TITLE
Add staking_competitors.json for DApp browser notices

### DIFF
--- a/dapps/staking_competitors.json
+++ b/dapps/staking_competitors.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "domains": [
+    "staking.polkadot.cloud"
+  ]
+}

--- a/dapps/staking_competitors_dev.json
+++ b/dapps/staking_competitors_dev.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "domains": [
+    "staking.polkadot.cloud"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `dapps/staking_competitors.json` and `dapps/staking_competitors_dev.json` — a runtime-fetched list of third-party staking domains that Nova Wallet's DApp browser shows notices for.

## Why

Today both iOS (`ThirdPartyStakingDomainMatcher.swift`) and Android (`StakingCompetitorDomains.kt`) hardcode the list. Moving it to nova-utils lets future curation ship without an app/store release and gives both platforms a single source of truth.

Companion PRs on the client side: novasamatech/nova-wallet-ios#1818, novasamatech/nova-wallet-android#2269 — those PRs add the Retrofit/JsonDataProvider plumbing that reads this file at runtime. They can merge before or after this PR (the in-memory cache fails open if the URL doesn't resolve yet — no notice appears until the file is live).

Supersedes the broader catalogue-curation approach in #4293 (now closed) — the current product scope is to show notices via a runtime-fetched domain list rather than hide competitor entries from the catalogue.