### PR TITLE
Update Kusama Asset Hub RPCs

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -421,12 +421,16 @@
         ],
         "nodes": [
             {
-                "url": "wss://sys.ibp.network/statemine",
-                "name": "IBP1 node"
+                "url": "wss://asset-hub-kusama-rpc.n.dwellir.com",
+                "name": "Dwellir node"
             },
             {
-                "url": "wss://asset-hub-kusama.dotters.network",
-                "name": "IBP2 node"
+                "url": "wss://rpc-asset-hub-kusama.luckyfriday.io",
+                "name": "Lucky Friday node"
+            },
+            {
+                "url": "wss://kusama-asset-hub-rpc.polkadot.io",
+                "name": "Parity node"
             }
         ],
         "explorers": [

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -544,12 +544,16 @@
         ],
         "nodes": [
             {
-                "url": "wss://sys.ibp.network/statemine",
-                "name": "IBP1 node"
+                "url": "wss://asset-hub-kusama-rpc.n.dwellir.com",
+                "name": "Dwellir node"
             },
             {
-                "url": "wss://asset-hub-kusama.dotters.network",
-                "name": "IBP2 node"
+                "url": "wss://rpc-asset-hub-kusama.luckyfriday.io",
+                "name": "Lucky Friday node"
+            },
+            {
+                "url": "wss://kusama-asset-hub-rpc.polkadot.io",
+                "name": "Parity node"
             }
         ],
         "explorers": [


### PR DESCRIPTION
Removes deprecated IBP nodes and adds 3 currently active RPCs:
wss://asset-hub-kusama-rpc.n.dwellir.com
wss://rpc-asset-hub-kusama.luckyfriday.io
wss://kusama-asset-hub-rpc.polkadot.io