### PR TITLE
Update Hydration RPCs

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -5067,16 +5067,24 @@
                 "name": "Novasama node"
             },
             {
-                "url": "wss://rpc.hydradx.cloud",
-                "name": "Galactic Council node"
+                "url": "wss://hydration-rpc.n.dwellir.com",
+                "name": "Dwellir node"
             },
             {
-                "url": "wss://hydration.ibp.network",
-                "name": "IBP1 node"
+                "url": "wss://hydration-rpc.neckwork.net",
+                "name": "Neckwork node"
             },
             {
-                "url": "wss://hydration.dotters.network",
-                "name": "IBP2 node"
+                "url": "wss://node-sparrow-1.sparrow.shadow-senate.com",
+                "name": "Sparrow node"
+            },
+            {
+                "url": "wss://hdx.tarn.hydration.cloud",
+                "name": "Tarn node"
+            },
+            {
+                "url": "wss://hydration.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -5377,16 +5377,24 @@
                 "name": "Novasama node"
             },
             {
-                "url": "wss://rpc.hydradx.cloud",
-                "name": "Galactic Council node"
+                "url": "wss://hydration-rpc.n.dwellir.com",
+                "name": "Dwellir node"
             },
             {
-                "url": "wss://hydration.ibp.network",
-                "name": "IBP1 node"
+                "url": "wss://hydration-rpc.neckwork.net",
+                "name": "Neckwork node"
             },
             {
-                "url": "wss://hydration.dotters.network",
-                "name": "IBP2 node"
+                "url": "wss://node-sparrow-1.sparrow.shadow-senate.com",
+                "name": "Sparrow node"
+            },
+            {
+                "url": "wss://hdx.tarn.hydration.cloud",
+                "name": "Tarn node"
+            },
+            {
+                "url": "wss://hydration.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [


### PR DESCRIPTION
Removes the unresponsive Galactic Council node and the deprecated IBP nodes, and adds 5 currently active RPCs:

wss://hydration-rpc.n.dwellir.com
wss://hydration-rpc.neckwork.net
wss://node-sparrow-1.sparrow.shadow-senate.com
wss://hdx.tarn.hydration.cloud
wss://hydration.rotko.net

Keeps the existing Novasama node.
