### PR TITLE
Update Hyperbrige RPCs on dev

### DIFF
--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -10179,16 +10179,8 @@
         ],
         "nodes": [
             {
-                "url": "wss://nexus.ibp.network",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://nexus.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
-                "url": "wss://hyperbridge-nexus-rpc.blockops.network",
-                "name": "BlockOps node"
+                "url": "wss://nexus.rpc.polytope.technology",
+                "name": "Polytope Labs node"
             }
         ],
         "explorers": [


### PR DESCRIPTION
Removes the unresponsive BlockOps node and the deprecated IBP nodes, and adds currently active Polytope Labs RPC (dev)

State before changes:
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/dc50b567-6c52-4e12-8aa1-3cacfe1d07ba" />
