### PR TITLE
Update Hyperbrige RPCs

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -8167,16 +8167,8 @@
         ],
         "nodes": [
             {
-                "url": "wss://nexus.ibp.network",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://nexus.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
-                "url": "wss://hyperbridge-nexus-rpc.blockops.network",
-                "name": "BlockOps node"
+                "url": "wss://nexus.rpc.polytope.technology",
+                "name": "Polytope Labs node"
             }
         ],
         "explorers": [


### PR DESCRIPTION
Removes the unresponsive BlockOps node and the deprecated IBP nodes, and adds currently active Polytope Labs RPC 

<table>
  <tr>
    <th colspan="2">State before changes</th>
  </tr>
  <tr>
    <td><img width="325" src="https://github.com/user-attachments/assets/18249f39-4c9b-489d-8ba0-22455b6d1ba8" /></td>
    <td><img width="325" src="https://github.com/user-attachments/assets/a9bb7aea-3610-49fe-90a3-8686abe4b8a9" /></td>
  </tr>
</table>

<table>
  <tr>
    <th colspan="2">State after changes</th>
  </tr>
  <tr>
    <td><img width="325" src="https://github.com/user-attachments/assets/4da9ee7e-17d9-4497-8ab2-73e543dcfff0" /></td>
    <td><img width="325" src="https://github.com/user-attachments/assets/44351778-28a6-490a-96ef-f872befd388c" /></td>
  </tr>
</table>


