### PR TITLE
Add Neckwork block explorer to Hydration

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -5092,6 +5092,12 @@
                 "name": "Subscan",
                 "extrinsic": "https://hydration.subscan.io/extrinsic/{hash}",
                 "account": "https://hydration.subscan.io/account/{address}"
+            },
+            {
+                "name": "Neckwork",
+                "extrinsic": "https://hydration-explorer.neckwork.net/extrinsic/{hash}",
+                "account": "https://hydration-explorer.neckwork.net/account/{address}",
+                "event": "https://hydration-explorer.neckwork.net/event/{event}"
             }
         ],
         "externalApi": {

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -5402,6 +5402,12 @@
                 "name": "Subscan",
                 "extrinsic": "https://hydration.subscan.io/extrinsic/{hash}",
                 "account": "https://hydration.subscan.io/account/{address}"
+            },
+            {
+                "name": "Neckwork",
+                "extrinsic": "https://hydration-explorer.neckwork.net/extrinsic/{hash}",
+                "account": "https://hydration-explorer.neckwork.net/account/{address}",
+                "event": "https://hydration-explorer.neckwork.net/event/{event}"
             }
         ],
         "externalApi": {


### PR DESCRIPTION
Adds the Neckwork explorer (`hydration-explorer.neckwork.net`) as a second block explorer option for Hydration, after the existing Subscan entry. Neckwork already runs a Hydration RPC node in this config — this exposes their explorer to users too.

Link templates (match the explorer's own routes):
- extrinsic → `/extrinsic/{hash}`
- account → `/account/{address}`
- event → `/event/{event}` — new; Hydration's Subscan entry has no event link

Applied to both `chains/v22/chains.json` and `chains/v22/chains_dev.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
