### PR TITLE
Update network status for 4 networks

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -1041,7 +1041,7 @@
     {
         "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
         "parentId": "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
-        "name": "Moonbeam",
+        "name": "Moonbeam (PAUSED)",
         "assets": [
             {
                 "assetId": 0,
@@ -1485,7 +1485,7 @@
     {
         "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-        "name": "Moonriver",
+        "name": "Moonriver (PAUSED)",
         "assets": [
             {
                 "assetId": 0,
@@ -3543,7 +3543,7 @@
     {
         "chainId": "9af9a64e6e4da8e3073901c3ff0cc4c3aad9563786d89daf6ad820b6e14a0b8b",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-        "name": "Kintsugi",
+        "name": "Kintsugi (PAUSED)",
         "assets": [
             {
                 "assetId": 0,
@@ -5128,7 +5128,7 @@
     {
         "chainId": "bf88efe70e9e0e916416e8bed61f2b45717f517d7f3523e33c7b001e5ffcbc72",
         "parentId": "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
-        "name": "Interlay",
+        "name": "Interlay (PAUSED)",
         "assets": [
             {
                 "assetId": 0,

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -1047,7 +1047,7 @@
     {
         "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-        "name": "Moonriver",
+        "name": "Moonriver (PAUSED)",
         "assets": [
             {
                 "assetId": 0,
@@ -1883,7 +1883,7 @@
     {
         "chainId": "9af9a64e6e4da8e3073901c3ff0cc4c3aad9563786d89daf6ad820b6e14a0b8b",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-        "name": "Kintsugi",
+        "name": "Kintsugi (PAUSED)",
         "assets": [
             {
                 "assetId": 0,
@@ -2742,7 +2742,7 @@
     {
         "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
         "parentId": "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
-        "name": "Moonbeam",
+        "name": "Moonbeam (PAUSED)",
         "assets": [
             {
                 "assetId": 0,
@@ -5438,7 +5438,7 @@
     {
         "chainId": "bf88efe70e9e0e916416e8bed61f2b45717f517d7f3523e33c7b001e5ffcbc72",
         "parentId": "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
-        "name": "Interlay",
+        "name": "Interlay (PAUSED)",
         "assets": [
             {
                 "assetId": 0,


### PR DESCRIPTION
Added "(PAUSED)" flag to 4 networks:
- Moonbeam
- Moonriver
- Interlay
- Kintsugi

A more detailed review of networks should be carried out, as there are likely more that are not producing blocks. 