### PR TITLE
Add Rotko nodes to Polkadot and Kusama system chains

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -3367,6 +3367,10 @@
             {
                 "url": "wss://asset-hub-polkadot.dotters.network",
                 "name": "IBP2 node"
+            },
+            {
+                "url": "wss://asset-hub-polkadot.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [

--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -431,6 +431,10 @@
             {
                 "url": "wss://kusama-asset-hub-rpc.polkadot.io",
                 "name": "Parity node"
+            },
+            {
+                "url": "wss://asset-hub-kusama.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -545,6 +549,10 @@
             {
                 "url": "wss://people-polkadot.public.curie.radiumblock.co/ws",
                 "name": "Radium node"
+            },
+            {
+                "url": "wss://people-polkadot.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -602,6 +610,10 @@
             {
                 "url": "wss://ksm-rpc.stakeworld.io/people",
                 "name": "Stakeworld node"
+            },
+            {
+                "url": "wss://people-kusama.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -3517,6 +3529,10 @@
             {
                 "url": "wss://api.kusama.encointer.org",
                 "name": "Encointer association node"
+            },
+            {
+                "url": "wss://encointer-kusama.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -7412,6 +7428,10 @@
             {
                 "url": "wss://dot-rpc.stakeworld.io/bridgehub",
                 "name": "Stakeworld node"
+            },
+            {
+                "url": "wss://bridge-hub-polkadot.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -7466,6 +7486,10 @@
             {
                 "url": "wss://ksm-rpc.stakeworld.io/bridgehub",
                 "name": "Stakeworld node"
+            },
+            {
+                "url": "wss://bridge-hub-kusama.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -7524,6 +7548,10 @@
             {
                 "url": "wss://dot-rpc.stakeworld.io/collectives",
                 "name": "Stakeworld node"
+            },
+            {
+                "url": "wss://collectives-polkadot.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -8854,6 +8882,10 @@
             {
                 "url": "wss://polkadot-coretime-rpc.polkadot.io",
                 "name": "Parity node"
+            },
+            {
+                "url": "wss://coretime-polkadot.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -8912,6 +8944,10 @@
             {
                 "url": "wss://ksm-rpc.stakeworld.io/coretime",
                 "name": "Stakeworld node"
+            },
+            {
+                "url": "wss://coretime-kusama.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -554,6 +554,10 @@
             {
                 "url": "wss://kusama-asset-hub-rpc.polkadot.io",
                 "name": "Parity node"
+            },
+            {
+                "url": "wss://asset-hub-kusama.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -3818,6 +3822,10 @@
             {
                 "url": "wss://asset-hub-polkadot.dotters.network",
                 "name": "IBP2 node"
+            },
+            {
+                "url": "wss://asset-hub-polkadot.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -3992,6 +4000,10 @@
             {
                 "url": "wss://api.kusama.encointer.org",
                 "name": "Encointer association node"
+            },
+            {
+                "url": "wss://encointer-kusama.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -8702,6 +8714,10 @@
             {
                 "url": "wss://dot-rpc.stakeworld.io/bridgehub",
                 "name": "Stakeworld node"
+            },
+            {
+                "url": "wss://bridge-hub-polkadot.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -8757,6 +8773,10 @@
             {
                 "url": "wss://ksm-rpc.stakeworld.io/bridgehub",
                 "name": "Stakeworld node"
+            },
+            {
+                "url": "wss://bridge-hub-kusama.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -8816,6 +8836,10 @@
             {
                 "url": "wss://dot-rpc.stakeworld.io/collectives",
                 "name": "Stakeworld node"
+            },
+            {
+                "url": "wss://collectives-polkadot.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -8882,6 +8906,10 @@
             {
                 "url": "wss://people-polkadot.public.curie.radiumblock.co/ws",
                 "name": "Radium node"
+            },
+            {
+                "url": "wss://people-polkadot.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -8939,6 +8967,10 @@
             {
                 "url": "wss://ksm-rpc.stakeworld.io/people",
                 "name": "Stakeworld node"
+            },
+            {
+                "url": "wss://people-kusama.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -11095,6 +11127,10 @@
             {
                 "url": "wss://polkadot-coretime-rpc.polkadot.io",
                 "name": "Parity node"
+            },
+            {
+                "url": "wss://coretime-polkadot.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [
@@ -11153,6 +11189,10 @@
             {
                 "url": "wss://ksm-rpc.stakeworld.io/coretime",
                 "name": "Stakeworld node"
+            },
+            {
+                "url": "wss://coretime-kusama.rotko.net",
+                "name": "Rotko node"
             }
         ],
         "explorers": [


### PR DESCRIPTION
Adds Rotko public RPC nodes to the Polkadot and Kusama system chains. Rotko already provides the Hydration node in this dataset (`wss://hydration.rotko.net`).

All endpoints are live and were verified with a `system_chain` call before submitting:

- Polkadot People: wss://people-polkadot.rotko.net
- Polkadot Bridge Hub: wss://bridge-hub-polkadot.rotko.net
- Polkadot Collectives: wss://collectives-polkadot.rotko.net
- Polkadot Coretime: wss://coretime-polkadot.rotko.net
- Kusama People: wss://people-kusama.rotko.net
- Kusama Asset Hub: wss://asset-hub-kusama.rotko.net
- Kusama Bridge Hub: wss://bridge-hub-kusama.rotko.net
- Kusama Coretime: wss://coretime-kusama.rotko.net
- Encointer: wss://encointer-kusama.rotko.net