### PR TITLE
Add Claude Code configuration, flake8 linting, and fix what it found

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; case \"$f\" in *.json) [ -x .venv/bin/pre-commit ] && .venv/bin/pre-commit run --files \"$f\";; esac; } 2>/dev/null || true",
+            "timeout": 120,
+            "statusMessage": "Running pre-commit on changed config..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/check-config/SKILL.md
+++ b/.claude/skills/check-config/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: check-config
+description: Validate changed JSON config files in this repo before opening a PR — checks that edits landed in the latest version directory, that the dev/prod pairing rule was respected, and runs the pre-commit hooks over the changed files. Use after editing anything under chains/, xcm/, dapps/, global/ or banners/.
+---
+
+Validate the config changes in the working tree the way CI will.
+
+## 1. Collect the changed files
+
+```bash
+git diff --name-only master...HEAD; git diff --name-only; git diff --name-only --cached
+```
+
+Deduplicate, then keep the `.json` files under `chains/`, `xcm/`, `dapps/`, `global/`, and `banners/`. If there are none, say so and stop.
+
+## 2. Check the version directory
+
+Changes belong in the latest version directory only — `chains/v22/` and `xcm/v8/` (confirm the latest by listing `chains/` and `xcm/`; do not assume these numbers stay current).
+
+Flag as a problem:
+- edits to an older `vNN` directory
+- edits to the legacy top-level `chains/chains.json`, `chains/chains_dev.json`, or `xcm/transfers*.json`
+
+## 3. Check the dev/prod pairing
+
+This repo promotes changes dev-first: a change should touch the `*_dev.json` half of a pair, not both halves in one PR.
+
+If both `chains_dev.json` and `chains.json` (or the `transfers`/`dapps`/`global/config` equivalents) are modified, flag it and ask whether this is an intentional promotion PR. Editing only the prod half is also worth flagging — the dev config would then be behind.
+
+## 4. Run the pre-commit hooks
+
+```bash
+.venv/bin/pre-commit run --files <changed files>
+```
+
+If `.venv` is missing, tell the user to run `make init` rather than installing anything yourself.
+
+These hooks (`check-chains-json`, `check-dapps-json`, `check-json`, `end-of-file-fixer`, `trailing-whitespace`) rewrite files in place. If they modified anything, re-read the file and report what changed — CI runs the same hooks and auto-commits their output onto the branch, so it is better to land those fixes yourself.
+
+## 5. Report
+
+Give a short verdict per check: version directory, dev/prod pairing, pre-commit result. State clearly that integration tests were not run — they hit live RPC nodes and run in CI on `chains/**` changes.

--- a/.claude/skills/promote-dev-to-prod/SKILL.md
+++ b/.claude/skills/promote-dev-to-prod/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: promote-dev-to-prod
+description: Promote config changes from the dev file to the prod file (chains or xcm). Interactive and writes to prod config — user-invoked only.
+disable-model-invocation: true
+---
+
+Promote dev config into prod. Argument: `$ARGUMENTS` — `chains` or `xcm`. If empty, ask which one.
+
+Both tools rewrite the prod config in place. Before running either, confirm the working tree is clean (`git status --short`) so the promotion diff is reviewable on its own, and confirm with the user which version directory is being promoted.
+
+## chains
+
+`chains/apply_dev_to_prod.py` opens `chains.json` and `chains_dev.json` by bare filename, so it must run from inside the version directory:
+
+```bash
+cd chains/v22 && PYTHONPATH=../.. ../../.venv/bin/python ../apply_dev_to_prod.py
+```
+
+Replace `v22` with the actual latest version directory — list `chains/` to confirm.
+
+It copies every dev entry whose `chainId` already exists in prod, non-interactively. Chains present only in dev are not added. It rewrites the whole file with `indent=4`, so review the diff for unintended reformatting.
+
+## xcm
+
+```bash
+DEV_XCM_JSON_PATH=xcm/v8/transfers_dev.json \
+XCM_JSON_PATH=xcm/v8/transfers.json \
+DEV_CHAINS_JSON_PATH=chains/v22/chains_dev.json \
+make update-xcm-to-prod
+```
+
+Replace the version numbers with the actual latest directories. This script prompts `y/n` for each new chain, asset, destination and reserve change — relay each prompt to the user and pass their answer through; do not answer on their behalf.
+
+## After promotion
+
+1. Show `git diff --stat` and walk the user through the substantive changes.
+2. Run the pre-commit hooks over the touched files (`.venv/bin/pre-commit run --files <files>`).
+3. Remind the user that promotion goes in its own PR against `master`, separate from the dev change.

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,13 @@
+[flake8]
+max-line-length = 120
+extend-exclude = .venv,__pycache__,.pytest_cache,allure-results
+
+# This codebase does not follow a single formatting style, and reformatting it
+# is not the point of linting here. Restrict flake8 to checks that flag real
+# defects: syntax errors (E9), statement problems such as bare except (E7),
+# and everything pyflakes reports — undefined names, unused imports/locals (F).
+select = E7,E9,F
+
+per-file-ignores =
+    # Package __init__ files re-export submodules.
+    __init__.py:F401

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,8 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
     -   id: check-json
+
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+    -   id: flake8

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ Run `make init` once to create `.venv`, install dependencies via poetry and inst
 
 Python scripts must run from the repo root with `PYTHONPATH=.` (the Makefile targets already do): `scripts/utils/work_with_data.py` resolves config paths against the current working directory.
 
+Several scripts do their work at module level rather than under `if __name__ == "__main__"` — importing `scripts/update_test_data.py` or `scripts/xcm_transfers/clean_up_legacy_directions.py` rewrites config files as a side effect. Never import a script to inspect it; read it instead. A few scripts also import their siblings as top-level modules (`from utils.work_with_data import ...`), so they only resolve when run as a script from their own directory, not as `scripts.<name>`.
+
 ## Tests
 
 Integration tests connect to live RPC nodes, take a long time, and are CI's job — `.github/workflows/run_integration_tests.yaml` runs them on any `chains/**` change. Do not run `make test-all` locally; use `make check-chains-file` for local verification.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+Static JSON configuration (networks, assets, XCM routes, dApps, banners, icons) served over raw GitHub to Nova Wallet clients. Most changes are data edits, not code. The Python in `scripts/` and `tests/` exists to generate, validate and integration-test that data.
+
+## Versioned config directories
+
+`chains/` and `xcm/` keep one directory per config version (`chains/v2`…`chains/v22`, `xcm/v2`…`xcm/v8`). Older versions stay frozen for older client releases.
+
+- Edit only the latest version: **`chains/v22/`** and **`xcm/v8/`**. Do not backport into older `vNN` directories.
+- `chains/chains.json`, `chains/chains_dev.json` and `xcm/transfers*.json` at the top level are legacy leftovers (untouched since 2023) — do not edit them.
+- The latest version is hardcoded in two places that must be updated when a new version directory is added: `scripts/utils/chain_model.py` (`latest_config_version()`, overridable via the `CHAINS_VERSION` env var) and `scripts/xcm_transfers/config_setup.py` (`XCM_VERSION`, no env override).
+
+## dev → prod flow
+
+Configs come in dev/prod pairs: `chains_dev.json`/`chains.json`, `transfers_dev.json`/`transfers.json`, `dapps_dev.json`/`dapps.json`, `global/config_dev.json`/`global/config.json`.
+
+Changes land in the `*_dev.json` file first, in their own PR, and are promoted to prod separately. Do not edit both halves of a pair in one change unless explicitly asked.
+
+Promotion tools:
+- chains: `chains/apply_dev_to_prod.py` — opens `chains.json`/`chains_dev.json` by bare filename, so run it from inside the version directory.
+- xcm: `make update-xcm-to-prod` — needs `DEV_XCM_JSON_PATH`, `XCM_JSON_PATH`, `DEV_CHAINS_JSON_PATH`; prompts y/n per change.
+
+## Generated files — never edit by hand
+
+- `chains/README.md` ← `make generate_network_list`
+- `dapps/README.md` ← `make generate_dapp_list`
+- `chains/types/*.json` ← `make generate_type_files`
+- `tests/data/xcm_data.json` ← `make generate_test_file`
+
+## Commands
+
+Run `make init` once to create `.venv`, install dependencies via poetry and install the pre-commit hook. Requires Python 3.10 — poetry pins `>=3.10,<3.11`; the `PYTHON_VERSION := 3.11` line in the Makefile is stale and has no effect.
+
+- `make check-chains-file` — validate chains JSON through pre-commit. This is the check to run after editing config.
+- `make help` — list all targets.
+- There is no `make test` or `make lint` target, despite the `.PHONY` line naming them. Python is linted by the flake8 pre-commit hook, configured in `.flake8` to report only real defects (`E7,E9,F`) — formatting is deliberately not enforced.
+
+Python scripts must run from the repo root with `PYTHONPATH=.` (the Makefile targets already do): `scripts/utils/work_with_data.py` resolves config paths against the current working directory.
+
+## Tests
+
+Integration tests connect to live RPC nodes, take a long time, and are CI's job — `.github/workflows/run_integration_tests.yaml` runs them on any `chains/**` change. Do not run `make test-all` locally; use `make check-chains-file` for local verification.
+
+For a single suite, targets like `make test-nodes-availability` exist. `CHAINS_JSON_PATH` selects the config file under test (defaults to the latest version's `chains.json`).
+
+## Repo etiquette
+
+- PRs target `master`.
+- Branch names use a type prefix: `fix/`, `feat/`, and similar.
+- CI runs pre-commit on every PR and auto-commits its fixes onto your branch, so run pre-commit before pushing to avoid surprise commits.

--- a/scripts/create_slip44_token_list.py
+++ b/scripts/create_slip44_token_list.py
@@ -1,6 +1,5 @@
 import requests
 import json
-import os
 
 from collections import defaultdict
 from typing import Dict, Tuple

--- a/scripts/generate_dapps_list.py
+++ b/scripts/generate_dapps_list.py
@@ -24,7 +24,7 @@ def generate_dapps_table():
 
 def generate_value_matrix():
     returning_array = []
-    with open(os.getcwd() + f"/dapps/dapps_full.json", 'r') as json_file:
+    with open(os.getcwd() + "/dapps/dapps_full.json", 'r') as json_file:
         data = json.load(json_file)
     for dapp in data['dapps']:
         network_data_array = []

--- a/scripts/print_xcm_changes.py
+++ b/scripts/print_xcm_changes.py
@@ -55,7 +55,7 @@ def compare_reserve_fee(object_accumulator, actual_assets_location, changed_asse
             if new_value != old_value:
                 object_accumulator['reserveFee'][assets] = {
                     'old_value': old_value, 'new_value': new_value}
-        except:
+        except Exception:
             object_accumulator['reserveFee'][assets] = "That asset was removed"
 
 
@@ -120,7 +120,8 @@ def find_new_destinations(object_accumulator, actual_chain_dict, new_cahin_dict,
                 actual_destinations = asset_in_actual_chain_dict.get(
                     'xcmTransfers')
                 try:
-                    destination_in_generated_chain_file = next(
+                    # Called for its side effect: StopIteration means the destination is new.
+                    next(
                         new_destination for new_destination in actual_destinations if new_destination.get('destination').get('chainId') == destination_chain_id)
                 except (StopIteration, KeyError, TypeError):
                     object_accumulator['chains'][chain_name][asset_symbol][destination_name] = 'That destination was added'

--- a/scripts/update_test_data.py
+++ b/scripts/update_test_data.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 from scripts.utils.chain_model import Chain
 
@@ -54,7 +53,8 @@ for dev_index, dev_id in enumerate(dev_ids):  # Add new network
 
         if options is not None:
             need_skip = [option for option in skip_options if option in options]
-            if need_skip: continue
+            if need_skip:
+                continue
 
         test_chains.append(chain_dict)
 

--- a/scripts/utils/chain_model.py
+++ b/scripts/utils/chain_model.py
@@ -78,7 +78,7 @@ class Chain:
                 connect_to_node(node_url)
                 print("Connected to ", node_url)
                 return
-            except:
+            except Exception:
                 print("Can't connect to", node_url)
                 continue
 

--- a/scripts/utils/metadata_interaction.py
+++ b/scripts/utils/metadata_interaction.py
@@ -286,7 +286,8 @@ def check_fee_is_calculating(substrate: SubstrateInterface) -> bool:
                 'value': 0,
             }
         )
-        query_info = substrate.get_payment_info(call=call, keypair=test_keypair)
+        # Called for its side effect: it raises if the payment info cannot be queried.
+        substrate.get_payment_info(call=call, keypair=test_keypair)
         return True
     except ValueError as value_error:
         print(f"Case when Balance pallet not found:\n{value_error}")
@@ -354,7 +355,8 @@ def account_does_not_need_updates(substrate: SubstrateInterface):
 
 
 def deep_search_an_elemnt_by_key(obj, key):
-    if key in obj: return obj[key]
+    if key in obj:
+        return obj[key]
     for k, v in obj.items():
         if isinstance(v,dict):
             item = deep_search_an_elemnt_by_key(v, key)

--- a/scripts/utils/work_with_data.py
+++ b/scripts/utils/work_with_data.py
@@ -16,11 +16,8 @@ def get_request_via_https(url) -> json:
 def get_network_list(path):
 
     dn = os.path.abspath('./')
-    try:
-        with open(dn + path) as fin:
-            chains_data = json.load(fin)
-    except:
-        raise
+    with open(dn + path) as fin:
+        chains_data = json.load(fin)
 
     return chains_data
 

--- a/scripts/xcm_transfers/clean_up_legacy_directions.py
+++ b/scripts/xcm_transfers/clean_up_legacy_directions.py
@@ -1,4 +1,3 @@
-import dataclasses
 import json
 from typing import Set, Tuple
 

--- a/scripts/xcm_transfers/config_setup.py
+++ b/scripts/xcm_transfers/config_setup.py
@@ -13,7 +13,7 @@ def get_xcm_config_files() -> XCMConfigFiles:
         return XCMConfigFiles(
             chains=f"chains/{CHAINS_VERSION}/chains.json",
             xcm_legacy_config=f"xcm/{XCM_VERSION}/transfers.json",
-            xcm_stable_legacy_config=f"xcm/v6/transfers.json",
+            xcm_stable_legacy_config="xcm/v6/transfers.json",
             xcm_additional_data="scripts/xcm_transfers/xcm_registry_additional_data.json",
             xcm_dynamic_config=f"xcm/{XCM_VERSION}/transfers_dynamic.json",
         )
@@ -22,7 +22,7 @@ def get_xcm_config_files() -> XCMConfigFiles:
         return XCMConfigFiles(
             chains=f"chains/{CHAINS_VERSION}/chains_dev.json",
             xcm_legacy_config=f"xcm/{XCM_VERSION}/transfers_dev.json",
-            xcm_stable_legacy_config=f"xcm/v6/transfers_dev.json",
+            xcm_stable_legacy_config="xcm/v6/transfers_dev.json",
             xcm_additional_data="scripts/xcm_transfers/xcm_registry_additional_data.json",
             xcm_dynamic_config=f"xcm/{XCM_VERSION}/transfers_dynamic_dev.json",
         )

--- a/scripts/xcm_transfers/determine_reserves.py
+++ b/scripts/xcm_transfers/determine_reserves.py
@@ -124,7 +124,7 @@ def main():
             success.append(direction)
             already_set_reserves.add(direction.origin_chain.chain.chainId)
         else:
-            print(f"  ✗ Failed with both reserves")
+            print("  ✗ Failed with both reserves")
             failure.append(direction)
 
     print("\n" + "="*80)

--- a/scripts/xcm_transfers/utils/account_id.py
+++ b/scripts/xcm_transfers/utils/account_id.py
@@ -1,7 +1,5 @@
 from scalecodec import ss58_decode
 
-from scripts.utils.chain_model import Chain
-
 
 def decode_account_id(address: str) -> str:
     if address.startswith("0x"):

--- a/scripts/xcm_transfers/xcm/dry_run/dry_run_api.py
+++ b/scripts/xcm_transfers/xcm/dry_run/dry_run_api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-from scalecodec import GenericCall, GenericEvent
+from scalecodec import GenericCall
 
 from scripts.xcm_transfers.xcm.dry_run.errors import is_xcm_run_error, handle_xcm_run_error_execution_result, \
     is_call_run_error, handle_call_run_error_execution_result

--- a/scripts/xcm_transfers/xcm/dry_run/dry_run_transfer.py
+++ b/scripts/xcm_transfers/xcm/dry_run/dry_run_transfer.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from scalecodec import GenericCall
 from substrateinterface import SubstrateInterface
 
-from scripts.xcm_transfers.utils.fix_scale_codec import fix_tuple_encoding, fix_substrate_interface
+from scripts.xcm_transfers.utils.fix_scale_codec import fix_substrate_interface
 from scripts.xcm_transfers.utils.weight import Weight
 from scripts.xcm_transfers.xcm.call_payment.call_payment_api import calculate_call_weight
 from scripts.xcm_transfers.xcm.dry_run.dry_run_api import dry_run_xcm_call, dry_run_final_xcm, dry_run_call
@@ -188,7 +188,7 @@ def _detect_supports_xcm_execute(xcm_chain: XcmChain) -> bool:
     error = extract_xcm_execute_error(execution_result, xcm_chain)
 
     if error is None:
-        print(f"Xcm execute status OK")
+        print("Xcm execute status OK")
     else:
         print(f"Xcm execute status error: {error}")
 

--- a/scripts/xcm_transfers/xcm/dry_run/events/xcm.py
+++ b/scripts/xcm_transfers/xcm/dry_run/events/xcm.py
@@ -24,7 +24,7 @@ def find_sent_xcm(
 ) -> VerionsedXcm:
     forwarded_xcm = _find_forwarded_xcm(success_dry_run_effects, final_destination_account)
     if forwarded_xcm is not None:
-        debug_log(f"Found sent xcm in forwarded xcms")
+        debug_log("Found sent xcm in forwarded xcms")
         return forwarded_xcm
 
     emitted_events = success_dry_run_effects["emitted_events"]

--- a/scripts/xcm_transfers/xcm/registry/TrustedTeleporters.py
+++ b/scripts/xcm_transfers/xcm/registry/TrustedTeleporters.py
@@ -1,4 +1,4 @@
-from scripts.utils.chain_model import ChainId, FullChainAssetId, ChainAssetId
+from scripts.utils.chain_model import ChainId, ChainAssetId
 from scripts.xcm_transfers.xcm.registry.xcm_chain import XcmChain
 
 CustomTeleportsEntry = (ChainId, ChainId, ChainAssetId)  # origin, destination, originAsset

--- a/scripts/xcm_transfers/xcm/registry/transfer_type.py
+++ b/scripts/xcm_transfers/xcm/registry/transfer_type.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Union
 
-from scripts.utils.chain_model import ChainAsset
 from scripts.xcm_transfers.xcm.registry.xcm_chain import XcmChain
 
 class TransferType(ABC):

--- a/scripts/xcm_transfers/xcm/registry/xcm_registry.py
+++ b/scripts/xcm_transfers/xcm/registry/xcm_registry.py
@@ -6,9 +6,8 @@ from typing import List, Callable
 from typing import NewType
 ChainId = NewType('ChainId', int)
 
-from scripts.utils.chain_model import Chain, ChainAssetId, ChainAsset
+from scripts.utils.chain_model import ChainAsset
 from scripts.xcm_transfers.xcm.registry import TrustedTeleporters
-from scripts.xcm_transfers.xcm.registry.parachain import Parachain
 from scripts.xcm_transfers.xcm.registry.reserve_location import ReserveLocations
 from scripts.xcm_transfers.xcm.registry.transfer_type import TransferType, Teleport, LocalReserve, DestinationReserve, \
     RemoteReserve

--- a/scripts/xcm_transfers/xcm/registry/xcm_registry_builder.py
+++ b/scripts/xcm_transfers/xcm/registry/xcm_registry_builder.py
@@ -6,7 +6,6 @@ from scalecodec import ScaleBytes
 from scripts.utils.chain_model import Chain
 from scripts.utils.work_with_data import get_data_from_file
 from scripts.xcm_transfers.utils.dry_run_api_types import dry_run_api_types
-from scripts.xcm_transfers.utils.log import debug_log
 from scripts.xcm_transfers.utils.xcm_config_files import XCMConfigFiles
 from scripts.xcm_transfers.xcm.multi_location import GlobalMultiLocation
 from scripts.xcm_transfers.xcm.registry.TrustedTeleporters import TrustedTeleporters, CustomTeleportsEntry

--- a/tests/test_can_query_base_parameters.py
+++ b/tests/test_can_query_base_parameters.py
@@ -3,19 +3,19 @@ from substrateinterface import SubstrateInterface
 
 class TestCanGetMetadata:
     def test_create_connection_and_get_metadata(self, connection_by_url: SubstrateInterface):
-        metadata = connection_by_url.get_block_metadata()
+        connection_by_url.get_block_metadata()
         assert isinstance(connection_by_url, SubstrateInterface)
 
 
 class TestCanGetFee:
     def test_create_connection_and_get_fee(self, connection_by_url: SubstrateInterface):
-        storage = connection_by_url.rpc_request('payment_queryInfo', [
+        connection_by_url.rpc_request('payment_queryInfo', [
             '0x41028400fdc41550fb5186d71cae699c31731b3e1baa10680c7bd6b3831a6d222cf4d16800080bfe8bc67f44b498239887dc5679523cfcb1d20fd9ec9d6bae0a385cca118d2cb7ef9f4674d52a810feb32932d7c6fe3e05ce9e06cd72cf499c8692206410ab5038800040000340a806419d5e278172e45cb0e50da1b031795366c99ddfe0a680bd53b142c630700e40b5402'])
         assert isinstance(connection_by_url, SubstrateInterface)
 
 
 class TestCanGetIndex:
     def test_create_connection_and_get_next_index(self, connection_by_url: SubstrateInterface):
-        storage = connection_by_url.rpc_request('account_nextIndex',
-                                                ['5CJqRchpnKQ6zzB4zmkz3QSzFgFmLFJ741RxW1CunStvEwKd'])
+        connection_by_url.rpc_request('account_nextIndex',
+                                      ['5CJqRchpnKQ6zzB4zmkz3QSzFgFmLFJ741RxW1CunStvEwKd'])
         assert isinstance(connection_by_url, SubstrateInterface)

--- a/tests/test_eth_nodes_availability.py
+++ b/tests/test_eth_nodes_availability.py
@@ -19,7 +19,7 @@ class TestETHNodesAvailability:
 
         # Measure time taken to retrieve current block
         start_time = time.time()
-        block = w3.eth.get_block('latest')
+        w3.eth.get_block('latest')
         end_time = time.time()
 
         # Check if request took more than 3 seconds

--- a/tests/test_subquery_is_synced.py
+++ b/tests/test_subquery_is_synced.py
@@ -1,5 +1,4 @@
 import requests
-from typing import List
 
 payload = "{\"query\":\"query{\\n  _metadata{\\n    chain\\n    lastProcessedHeight\\n    targetHeight\\n  }\\n}\",\"variables\":{}}"
 headers = {

--- a/tests/test_substrate_node_is_synced.py
+++ b/tests/test_substrate_node_is_synced.py
@@ -17,7 +17,7 @@ def test_rpc_node_is_synced(connection_by_url: SubstrateInterface):
 
         else:
             assert False, "Failed to retrieve SyncState"
-    except SubstrateRequestException as err:
+    except SubstrateRequestException:
         # If we catch Method not found Exception -> then check internal network time
         system_timestamp = connection_by_url.query("Timestamp", "Now").value / 1000
         assert abs(time.time() - system_timestamp) < 600  # 10 min = 10 * 60s

--- a/xcm/update_to_prod.py
+++ b/xcm/update_to_prod.py
@@ -82,9 +82,9 @@ def update_destinations(dev_chains, prod_chains, meta_dict):
         for prod_asset_location, prod_asset in prod_chain['assets'].items():
 
             if dev_chains[prod_chain_id]['assets'].get(prod_asset_location) is None:
-                print(f"Destination was removed in {meta_dict[prod_chain_id]['name']} \
-                          \nfor asset: {prod_asset_location} \
-                          \nto network: {meta_dict[dev_destination_id]['name']} ")
+                # The whole asset is gone from dev, so every destination of it is removed.
+                print(f"Asset was removed in {meta_dict[prod_chain_id]['name']} \
+                          \nfor asset: {prod_asset_location} ")
                 if ask_to_update():
                     prod_chains[prod_chain_id]['assets'][prod_asset_location] = None
             else:


### PR DESCRIPTION
## What

Adds Claude Code configuration for this repo, wires up the flake8 that was already a dependency but ran nowhere, and fixes everything it reports so the branch is green.

### `CLAUDE.md`
Documents only what is not derivable from the code itself:
- edits go into the latest version directory only (`chains/v22`, `xcm/v8`); the top-level `chains/chains.json` and `xcm/transfers*.json` are legacy, untouched since 2023
- the latest version is hardcoded in `scripts/utils/chain_model.py` and `scripts/xcm_transfers/config_setup.py` and must be updated when a version directory is added
- the dev → prod promotion flow and the tools for it
- which files are generated and must not be hand-edited
- Python 3.10 constraint (poetry pins `>=3.10,<3.11`; the `PYTHON_VERSION := 3.11` line in the Makefile has no effect), and that scripts must run from the repo root with `PYTHONPATH=.`
- that several scripts do their work at module level and rewrite config files when imported, so they must be read rather than imported
- integration tests hit live RPC nodes and belong to CI

### Skills
- `/check-config` — validates changed JSON configs before a PR: version directory, dev/prod pairing, pre-commit over the changed files
- `/promote-dev-to-prod` — wraps `chains/apply_dev_to_prod.py` and `make update-xcm-to-prod` with the correct working directory and env vars. User-invoked only, since both write to prod config

### Hook
`PostToolUse` on `Write|Edit` runs `pre-commit` over any JSON file Claude Code edits, so the `Check commit rules` job does not have to auto-commit the fixes onto the branch afterwards.

### flake8
`flake8` was in `pyproject.toml` but had no config and was not run by pre-commit or CI. It is now a pre-commit hook, configured in `.flake8` to report real defects (`E7,E9,F`) rather than formatting — the codebase does not follow one style and reformatting it is not the goal here. At the default 79-column limit this would have reported 517 `E501` violations alone; with this configuration it reported 32 findings, all fixed here.

### The one real bug

`xcm/update_to_prod.py` referenced `dev_destination_id` in the "destination removed" branch, where that name is never bound — the branch raised `NameError` instead of printing. It fires when the whole asset is missing from dev rather than a single destination, so the message now says that.

The remaining 31 findings were unused imports and locals, f-strings without placeholders, two statements sharing a line, and three bare excepts. `get_network_list` had a `try: ... except: raise` that did nothing and is gone; the other two now catch `Exception`, so `KeyboardInterrupt` is no longer swallowed while looping over unreachable nodes. Calls kept for their side effects lost only their unused bindings, so behaviour is unchanged.

