### PR TITLE
fix: drop rpc nodes on hosts that no longer resolve

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -22,14 +22,6 @@
                 "name": "Novasama node"
             },
             {
-                "url": "wss://rpc.ibp.network/polkadot",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://apps-rpc.polkadot.io",
                 "name": "Public node",
                 "features": [
@@ -142,14 +134,6 @@
             {
                 "url": "wss://rpc-kusama-2.novasama-tech.org",
                 "name": "Novasama node"
-            },
-            {
-                "url": "wss://rpc.ibp.network/kusama",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://kusama.dotters.network",
-                "name": "IBP2 node"
             },
             {
                 "url": "wss://apps-kusama-rpc.polkadot.io",
@@ -535,14 +519,6 @@
                 ]
             },
             {
-                "url": "wss://sys.ibp.network/people-polkadot",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://people-polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://rpc-people-polkadot.luckyfriday.io",
                 "name": "LuckyFriday node"
             },
@@ -598,14 +574,6 @@
                 "features": [
                     "noTls12"
                 ]
-            },
-            {
-                "url": "wss://sys.ibp.network/people-kusama",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://people-kusama.dotters.network",
-                "name": "IBP2 node"
             },
             {
                 "url": "wss://ksm-rpc.stakeworld.io/people",
@@ -3361,14 +3329,6 @@
                 "name": "Dwellir node"
             },
             {
-                "url": "wss://sys.ibp.network/asset-hub-polkadot",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://asset-hub-polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://asset-hub-polkadot.rotko.net",
                 "name": "Rotko node"
             }
@@ -3522,14 +3482,6 @@
             }
         ],
         "nodes": [
-            {
-                "url": "wss://sys.ibp.network/encointer-kusama",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://encointer-kusama.dotters.network",
-                "name": "IBP2 node"
-            },
             {
                 "url": "wss://api.kusama.encointer.org",
                 "name": "Encointer association node"
@@ -5922,14 +5874,6 @@
         ],
         "nodes": [
             {
-                "url": "wss://bifrost-polkadot.ibp.network",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://bifrost-polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://hk.p.bifrost-rpc.liebi.com/ws",
                 "name": "Liebi node"
             },
@@ -6036,14 +5980,6 @@
             {
                 "url": "wss://asia-ws.unique.network/",
                 "name": "Unique Asia node"
-            },
-            {
-                "url": "wss://unique.ibp.network",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://unique.dotters.network",
-                "name": "IBP2 node"
             }
         ],
         "explorers": [
@@ -7101,14 +7037,6 @@
             {
                 "url": "wss://rpc-para.ajuna.network",
                 "name": "Ajuna node"
-            },
-            {
-                "url": "wss://ajuna.ibp.network",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://ajuna.dotters.network",
-                "name": "IBP2 node"
             }
         ],
         "explorers": [
@@ -7422,14 +7350,6 @@
         ],
         "nodes": [
             {
-                "url": "wss://sys.ibp.network/bridgehub-polkadot",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://bridge-hub-polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://dot-rpc.stakeworld.io/bridgehub",
                 "name": "Stakeworld node"
             },
@@ -7480,14 +7400,6 @@
         ],
         "nodes": [
             {
-                "url": "wss://sys.ibp.network/bridgehub-kusama",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://bridge-hub-kusama.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://ksm-rpc.stakeworld.io/bridgehub",
                 "name": "Stakeworld node"
             },
@@ -7537,14 +7449,6 @@
             }
         ],
         "nodes": [
-            {
-                "url": "wss://sys.ibp.network/collectives-polkadot",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://collectives-polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
             {
                 "url": "wss://collectives.public.curie.radiumblock.co/ws",
                 "name": "Radium node"
@@ -8872,14 +8776,6 @@
         ],
         "nodes": [
             {
-                "url": "wss://sys.ibp.network/coretime-polkadot",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://coretime-polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://rpc-coretime-polkadot.luckyfriday.io",
                 "name": "LuckyFriday node"
             },
@@ -8929,14 +8825,6 @@
             }
         ],
         "nodes": [
-            {
-                "url": "wss://sys.ibp.network/coretime-kusama",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://coretime-kusama.dotters.network",
-                "name": "IBP2 node"
-            },
             {
                 "url": "wss://rpc-coretime-kusama.luckyfriday.io",
                 "name": "LuckyFriday node"

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -22,14 +22,6 @@
                 "name": "Novasama node"
             },
             {
-                "url": "wss://rpc.ibp.network/polkadot",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://apps-rpc.polkadot.io",
                 "name": "Public node",
                 "features": [
@@ -156,14 +148,6 @@
             {
                 "url": "wss://rpc-kusama-2.novasama-tech.org",
                 "name": "Novasama node"
-            },
-            {
-                "url": "wss://rpc.ibp.network/kusama",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://kusama.dotters.network",
-                "name": "IBP2 node"
             },
             {
                 "url": "wss://apps-kusama-rpc.polkadot.io",
@@ -358,14 +342,6 @@
             {
                 "url": "wss://westmint-rpc-tn.dwellir.com",
                 "name": "Dwellir Tunisia"
-            },
-            {
-                "url": "wss://sys.ibp.network/asset-hub-westend",
-                "name": "IBP1"
-            },
-            {
-                "url": "wss://asset-hub-westend.dotters.network",
-                "name": "IBP2"
             },
             {
                 "url": "wss://westend-asset-hub-rpc.polkadot.io",
@@ -3816,14 +3792,6 @@
                 "name": "Dwellir node"
             },
             {
-                "url": "wss://sys.ibp.network/asset-hub-polkadot",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://asset-hub-polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://asset-hub-polkadot.rotko.net",
                 "name": "Rotko node"
             }
@@ -3989,14 +3957,6 @@
             }
         ],
         "nodes": [
-            {
-                "url": "wss://sys.ibp.network/encointer-kusama",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://encointer-kusama.dotters.network",
-                "name": "IBP2 node"
-            },
             {
                 "url": "wss://api.kusama.encointer.org",
                 "name": "Encointer association node"
@@ -6361,14 +6321,6 @@
         ],
         "nodes": [
             {
-                "url": "wss://bifrost-polkadot.ibp.network",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://bifrost-polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://hk.p.bifrost-rpc.liebi.com/ws",
                 "name": "Liebi node"
             },
@@ -6478,14 +6430,6 @@
             {
                 "url": "wss://asia-ws.unique.network/",
                 "name": "Unique Asia node"
-            },
-            {
-                "url": "wss://unique.ibp.network",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://unique.dotters.network",
-                "name": "IBP2 node"
             }
         ],
         "explorers": [
@@ -6867,14 +6811,6 @@
             {
                 "url": "wss://asset-hub-paseo-rpc.n.dwellir.com",
                 "name": "Dwellir"
-            },
-            {
-                "url": "wss://sys.ibp.network/asset-hub-paseo",
-                "name": "IBP1"
-            },
-            {
-                "url": "wss://asset-hub-paseo.dotters.network",
-                "name": "IBP2"
             },
             {
                 "url": "wss://pas-rpc.stakeworld.io/assethub",
@@ -8225,14 +8161,6 @@
             {
                 "url": "wss://rpc-para.ajuna.network",
                 "name": "Ajuna node"
-            },
-            {
-                "url": "wss://ajuna.ibp.network",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://ajuna.dotters.network",
-                "name": "IBP2 node"
             }
         ],
         "explorers": [
@@ -8704,14 +8632,6 @@
         ],
         "nodes": [
             {
-                "url": "wss://sys.ibp.network/bridgehub-polkadot",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://bridge-hub-polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://dot-rpc.stakeworld.io/bridgehub",
                 "name": "Stakeworld node"
             },
@@ -8763,14 +8683,6 @@
         ],
         "nodes": [
             {
-                "url": "wss://sys.ibp.network/bridgehub-kusama",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://bridge-hub-kusama.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://ksm-rpc.stakeworld.io/bridgehub",
                 "name": "Stakeworld node"
             },
@@ -8821,14 +8733,6 @@
             }
         ],
         "nodes": [
-            {
-                "url": "wss://sys.ibp.network/collectives-polkadot",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://collectives-polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
             {
                 "url": "wss://collectives.public.curie.radiumblock.co/ws",
                 "name": "Radium node"
@@ -8892,14 +8796,6 @@
                 ]
             },
             {
-                "url": "wss://sys.ibp.network/people-polkadot",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://people-polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://rpc-people-polkadot.luckyfriday.io",
                 "name": "LuckyFriday node"
             },
@@ -8955,14 +8851,6 @@
                 "features": [
                     "noTls12"
                 ]
-            },
-            {
-                "url": "wss://sys.ibp.network/people-kusama",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://people-kusama.dotters.network",
-                "name": "IBP2 node"
             },
             {
                 "url": "wss://ksm-rpc.stakeworld.io/people",
@@ -9888,14 +9776,6 @@
             {
                 "url": "wss://westend-bridge-hub-rpc-tn.dwellir.com",
                 "name": "Dwellir Tunisia node"
-            },
-            {
-                "url": "wss://sys.ibp.network/bridgehub-westend",
-                "name": "IBP-GeoDNS1 node"
-            },
-            {
-                "url": "wss://bridge-hub-westend.dotters.network",
-                "name": "IBP-GeoDNS2 node"
             },
             {
                 "url": "wss://westend-bridge-hub-rpc.polkadot.io",
@@ -11113,14 +10993,6 @@
         ],
         "nodes": [
             {
-                "url": "wss://sys.ibp.network/coretime-polkadot",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://coretime-polkadot.dotters.network",
-                "name": "IBP2 node"
-            },
-            {
                 "url": "wss://rpc-coretime-polkadot.luckyfriday.io",
                 "name": "LuckyFriday node"
             },
@@ -11170,14 +11042,6 @@
             }
         ],
         "nodes": [
-            {
-                "url": "wss://sys.ibp.network/coretime-kusama",
-                "name": "IBP1 node"
-            },
-            {
-                "url": "wss://coretime-kusama.dotters.network",
-                "name": "IBP2 node"
-            },
             {
                 "url": "wss://rpc-coretime-kusama.luckyfriday.io",
                 "name": "LuckyFriday node"


### PR DESCRIPTION
## What

Every `ibp.network` and `dotters.network` RPC endpoint in the v22 config is dead. This removes them: **28 urls from `chains.json`, 34 from `chains_dev.json`**, across 14 networks.

Rebased onto master after #4365.

## Evidence

| host pattern | DNS status | meaning |
|---|---|---|
| `rpc.ibp.network`, `sys.ibp.network` | `NXDOMAIN` | the `ibp.network` zone is alive and answers, but these subdomains were removed |
| `dotters.network` | `SERVFAIL`, no NS records at the apex | the zone itself is broken |

Checked against two independent public resolvers (1.1.1.1 and 8.8.8.8), so this is not a local-network artefact. Corroborated by polkadot-js/apps: its current endpoint files contain **zero** references to either domain, while our config had 35.

## Impact

Node counts before → after (prod), recomputed on top of #4365:

```
Polkadot Relay        9 -> 7      Bifrost Polkadot      4 -> 2
Kusama Relay          8 -> 6      UNIQUE                5 -> 3
Polkadot People       6 -> 4      Ajuna                 3 -> 1
Kusama People         5 -> 3      Polkadot Bridge Hub   4 -> 2
Polkadot Asset Hub    5 -> 3      Kusama Bridge Hub     4 -> 2
Encointer             4 -> 2      Polkadot Collectives  5 -> 3
Polkadot Coretime     5 -> 3      Kusama Coretime       6 -> 4
```

Every one of these keeps at least one node that answered during the audit.

Merging #4365 first paid off: the Rotko endpoints it added mean **only Ajuna** is left on a single node, rather than the four networks this would have reduced before. Ajuna's remaining node `wss://rpc-para.ajuna.network` is up and synced (4 peers, `isSyncing: false`), but a second endpoint for it would be worth adding.

## Deliberately not touched

- **Networks that are paused, or proposed for pausing in #4369** — left to that change so the two stay independent. Verified they merge cleanly in either order.
- **`Paseo Relay Testnet` (dev config)** — *both* of its nodes are on dead hosts. Removing them would leave the network with no nodes at all, so it needs replacement endpoints rather than deletion.

## How this was checked

Every node url in `chains/v22/chains.json` was probed over JSON-RPC (`chain_getBlockHash`, `chain_getHeader`) in two passes, failures were re-resolved against a public resolver to separate "host is gone" from a transient error, and the run was repeated on a second day with the same result. Control endpoints known to be up (Polkadot, Astar, Hydration) answered 3/3 throughout.
