### PR TITLE
fix: correct the dev/prod rule in the check-config skill

### DIFF
--- a/.claude/skills/check-config/SKILL.md
+++ b/.claude/skills/check-config/SKILL.md
@@ -23,9 +23,13 @@ Flag as a problem:
 
 ## 3. Check the dev/prod pairing
 
-This repo promotes changes dev-first: a change should touch the `*_dev.json` half of a pair, not both halves in one PR.
+Which rule applies depends on what the change does — the repo does not treat every edit the same way.
 
-If both `chains_dev.json` and `chains.json` (or the `transfers`/`dapps`/`global/config` equivalents) are modified, flag it and ask whether this is an intentional promotion PR. Editing only the prod half is also worth flagging — the dev config would then be behind.
+**Adding a network or an asset** goes dev-first: it lands in the `*_dev.json` half, and reaches prod later through `chains/apply_dev_to_prod.py` or `make update-xcm-to-prod`. Touching both halves in one PR here is worth questioning.
+
+**Changing nodes, or marking a network `(PAUSED)`**, goes into both files in the same PR. Every pause and node PR in the history does this — see #4362, #4300, #4227, #4223, #4111 — so a node change touching only one half is the thing to flag, not the reverse. Node updates are occasionally split into a paired prod PR and dev PR instead (#4351 / #4352); that is fine too, as long as both halves land.
+
+In either case, flag a change that reaches only one half with no sign the other is coming: the configs drifting apart is the actual failure mode.
 
 ## 4. Run the pre-commit hooks
 


### PR DESCRIPTION
The `check-config` skill added in #4366 encoded the dev/prod rule too narrowly.

It said every change goes dev-first and that touching both `chains.json` and `chains_dev.json` in one PR should be questioned. That holds for **adding a network or asset** — those land in the dev config and reach prod via `apply_dev_to_prod.py` / `make update-xcm-to-prod`.

It does not hold for **node changes and `(PAUSED)` renames**, which go into both files in the same PR. Every such PR in the history does it that way: #4362, #4300, #4227, #4223, #4111. Node updates are sometimes split into a paired prod PR and dev PR instead (#4351 / #4352), which is fine as long as both halves land.

As written the skill would flag perfectly correct PRs and stay silent on the actual failure mode — the two configs drifting apart. This rewrites the check to branch on what the change does, and to flag a change reaching only one half with no sign the other is coming.

Found while using the skill on #4337.