### PR TITLE
Remove inactive dapps and fix Basilisk/Taostats URLs

### DIFF
--- a/dapps/dapps.json
+++ b/dapps/dapps.json
@@ -10,22 +10,7 @@
       "url": "https://app.snowbridge.network/"
     },
     {
-      "url": "https://flappywud.lol/"
-    },
-    {
-      "url": "https://kodadot.xyz/"
-    },
-    {
       "url": "https://polkadot.subsquare.io/"
-    },
-    {
-      "url": "https://polkadot.polkassembly.io/"
-    },
-    {
-      "url": "https://play.chessonchain.io"
-    },
-    {
-      "url": "https://app.phala.network/"
     },
     {
       "url": "https://portal.astar.network/"
@@ -38,12 +23,6 @@
     },
     {
       "url": "https://app.hyperbridge.network/"
-    },
-    {
-      "url": "https://app.mimir.global/welcome?network=polkadot"
-    },
-    {
-      "url": "https://dotmemo.xyz/"
     }
   ],
   "categories": [
@@ -111,14 +90,6 @@
       ]
     },
     {
-      "name": "Phala App",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Phala.svg",
-      "url": "https://app.phala.network/",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
       "name": "Hyperbridge",
       "url": "https://app.hyperbridge.network/",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Hyperbridge.svg",
@@ -153,34 +124,6 @@
       ]
     },
     {
-      "name": "Moonbeam App",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Moonbeam.svg",
-      "url": "https://apps.moonbeam.network/moonbeam",
-      "categories": [
-        "staking",
-        "utilities",
-        "evm"
-      ]
-    },
-    {
-      "name": "Stellaswap",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/StellaSwap.svg",
-      "url": "https://app.stellaswap.com/exchange/swap",
-      "categories": [
-        "bridge",
-        "dex",
-        "evm"
-      ]
-    },
-    {
-      "name": "Polkassembly",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Polkassembly.svg",
-      "url": "https://polkadot.polkassembly.io/",
-      "categories": [
-        "governance"
-      ]
-    },
-    {
       "name": "Subsquare",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/SubSquare.svg",
       "url": "https://polkadot.subsquare.io/",
@@ -189,150 +132,12 @@
       ]
     },
     {
-      "name": "KodaDot",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/KodaDot.svg",
-      "url": "https://kodadot.xyz/",
-      "categories": [
-        "art"
-      ]
-    },
-    {
-      "name": "Singular",
-      "url": "https://singular.app/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Singular.svg",
-      "categories": [
-        "art"
-      ]
-    },
-    {
-      "name": "Dotmemo",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/.MEMO.svg",
-      "url": "https://dotmemo.xyz/",
-      "categories": [
-        "art",
-        "social",
-        "gaming"
-      ]
-    },
-    {
-      "name": "Raresama",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Raresama.svg",
-      "url": "https://raresama.com/",
-      "categories": [
-        "art",
-        "evm"
-      ]
-    },
-    {
-      "name": "Proof of Chaos",
-      "url": "https://www.proofofchaos.app/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Proof_of_Chaos.svg",
-      "categories": [
-        "art",
-        "governance"
-      ]
-    },
-    {
-      "name": "FlappyWUD",
-      "url": "https://flappywud.lol/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/FlappyWUD.png",
-      "categories": [
-        "gaming"
-      ]
-    },
-    {
-      "name": "ChessOnChain",
-      "url": "https://play.chessonchain.io",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/ChessOnChain.svg",
-      "categories": [
-        "gaming"
-      ]
-    },
-    {
-      "name": "Skybreach",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Skybreach.png",
-      "url": "https://skybreach.app/",
-      "categories": [
-        "evm",
-        "gaming"
-      ]
-    },
-    {
-      "name": "Grill",
-      "url": "https://grillapp.net/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Grill.svg",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "Sub.ID",
-      "url": "https://sub.id/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Sub.ID.svg",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Dotmarketcap",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Dotmarketcap.svg",
-      "url": "https://dotmarketcap.com/",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "Kintsugi Hub",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Kintsugi.svg",
-      "url": "https://kintsugi.interlay.io/",
-      "categories": [
-        "bridge",
-        "staking"
-      ]
-    },
-    {
-      "name": "Karura App (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Karura.svg",
-      "url": "https://apps.karura.network/",
-      "categories": [
-        "staking"
-      ],
-      "desktopOnly": true
-    },
-    {
       "name": "ArthSwap",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/ArthSwap.svg",
       "url": "https://app.arthswap.org/#/swap",
       "categories": [
         "dex",
         "evm"
-      ]
-    },
-    {
-      "name": "cBRIDGE",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/cBRIDGE.svg",
-      "url": "https://cbridge.celer.network/",
-      "categories": [
-        "dex",
-        "evm"
-      ]
-    },
-    {
-      "name": "XDAO",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/XDAO.svg",
-      "url": "https://www.xdao.app/1284",
-      "categories": [
-        "bridge",
-        "dex",
-        "evm"
-      ]
-    },
-    {
-      "name": "Polkawatch",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Polkawatch.svg",
-      "url": "https://polkawatch.app/",
-      "categories": [
-        "utilities"
       ]
     },
     {
@@ -345,114 +150,12 @@
       ]
     },
     {
-      "name": "Moonsama",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Moonsama.svg",
-      "url": "https://marketplace.moonsama.com/",
-      "categories": [
-        "art",
-        "evm"
-      ]
-    },
-    {
-      "name": "Darwinia Portal",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Darwinia.svg",
-      "url": "https://apps.darwinia.network/",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
       "name": "Basilisk Snek Swap",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/SnekSwap.svg",
-      "url": "https://app.basilisk.cloud/trade",
+      "url": "https://app.basilisk.cloud/",
       "categories": [
         "bridge",
         "dex"
-      ]
-    },
-    {
-      "name": "Zeitgeist",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Zeitgeist.svg",
-      "url": "https://app.zeitgeist.pm/",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Polkadex Orderbook",
-      "url": "https://orderbook.polkadex.trade/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Polkadex.svg",
-      "categories": [
-        "dex",
-        "utilities"
-      ]
-    },
-    {
-      "name": "Interlay Bitcoin DeFi Hub",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Interlay.svg",
-      "url": "https://app.interlay.io/",
-      "categories": [
-        "bridge",
-        "staking"
-      ]
-    },
-    {
-      "name": "xx network Hub",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/xx.svg",
-      "url": "https://hub.xx.network/",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Acala App (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Acala.svg",
-      "url": "https://apps.acala.network/",
-      "categories": [
-        "staking"
-      ],
-      "desktopOnly": true
-    },
-    {
-      "name": "Zenlink",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Zenlink.svg",
-      "url": "https://app.zenlink.pro",
-      "categories": [
-        "dex"
-      ]
-    },
-    {
-      "name": "KILT Stakeboard (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Kilt.svg",
-      "url": "https://stakeboard.kilt.io/",
-      "categories": [
-        "staking"
-      ],
-      "desktopOnly": true
-    },
-    {
-      "name": "Secret Stash",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Secret_stash.png",
-      "url": "https://secret-stash.io/",
-      "categories": [
-        "art"
-      ]
-    },
-    {
-      "name": "GIANTProtocol",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Giant.svg",
-      "url": "https://app.giantprotocol.org/shop",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Pendulum Chain Portal",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Pendulum.svg",
-      "url": "https://portal.pendulumchain.org/pendulum/dashboard",
-      "categories": [
-        "utilities",
-        "staking"
       ]
     },
     {
@@ -464,16 +167,6 @@
       ]
     },
     {
-      "name": "Awesome Ajuna Avatars (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/AwesomeAjunaAvatars.svg",
-      "url": "https://aaa.ajuna.io/",
-      "categories": [
-        "art",
-        "gaming"
-      ],
-      "desktopOnly": true
-    },
-    {
       "name": "Tensor Wallet",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/TensorWallet.svg",
       "url": "https://tensorwallet.ca/",
@@ -483,186 +176,11 @@
       ]
     },
     {
-      "name": "AZERO.ID",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/AzeroID.svg",
-      "url": "https://azero.id/dashboard",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Omni Liquid Staking",
-      "url": "https://omni.ls/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/OmniLS.svg",
-      "categories": [
-        "staking",
-        "evm"
-      ]
-    },
-    {
-      "name": "Joystream Governance App",
-      "url": "https://pioneerapp.xyz/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Pioneer.svg",
-      "categories": [
-        "governance"
-      ]
-    },
-    {
-      "name": "Gleev",
-      "url": "https://gleev.xyz/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Gleev.svg",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "InvArch Dashboard",
-      "url": "https://portal.invarch.network/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/InvArch.svg",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
-      "name": "Ternoa HUB",
-      "url": "https://hub.ternoa.network/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Ternoa.png",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
-      "name": "Capital Curio",
-      "url": "https://capitaldex.exchange/staking",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/CapitalDEX.svg",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
-      "name": "Polymesh Portal",
-      "url": "https://portal.polymesh.network/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Polymesh.png",
-      "categories": [
-        "utilities",
-        "staking"
-      ]
-    },
-    {
-      "name": "Battleship",
-      "url": "https://battleship.vara.network/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Battleship.svg",
-      "categories": [
-        "gaming"
-      ]
-    },
-    {
       "name": "Taostats",
-      "url": "https://dash.taostats.io/",
+      "url": "https://taostats.io",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Taostats.svg",
       "categories": [
         "staking"
-      ]
-    },
-    {
-      "name": "Big Ballz of Bajun",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/BigBallzOfBajun.png",
-      "url": "https://bbb.ajuna.io/",
-      "categories": [
-        "art",
-        "gaming"
-      ]
-    },
-    {
-      "name": "Mentat Minds",
-      "url": "https://mentatminds.com/delegate/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/MentatMinds.svg",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
-      "name": "Nodle client",
-      "url": "https://client.nodle.com/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/NodleClient.svg",
-      "categories": [
-        "utilities"
-      ],
-      "desktopOnly": true
-    },
-    {
-      "name": "Incognitee Privacy Sidechains Dapp",
-      "url": "https://app.incognitee.io/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Incognitee.svg",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Aleph Zero MOST",
-      "url": "https://mo.st/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Most.svg",
-      "categories": [
-        "bridge",
-        "dex"
-      ]
-    },
-    {
-      "name": "Euphrates (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Euphrates.svg",
-      "url": "https://farm.acala.network/",
-      "categories": [
-        "staking"
-      ],
-      "desktopOnly": true
-    },
-    {
-      "name": "Mimir",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Mimir.svg",
-      "url": "https://app.mimir.global/welcome?network=polkadot",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "AirLyft Campaigns",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/AirLyft.svg",
-      "url": "https://airlyft.one/",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "Unique PlayX",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Unique-playX.svg",
-      "url": "https://playx.unique.network",
-      "categories": [
-        "gaming"
-      ]
-    },
-    {
-      "name": "Unique Marketplace",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Unique.svg",
-      "url": "https://unqnft.io",
-      "categories": [
-        "gaming",
-        "art"
-      ]
-    },
-    {
-      "name": "Unlock Polkadot",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Unlockpolkadot.svg",
-      "url": "https://unlockpolkadot.com",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "DOT Yappers",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Dotyappers.png",
-      "url": "https://dotyappers.com",
-      "categories": [
-        "social"
       ]
     },
     {
@@ -672,55 +190,6 @@
       "categories": [
         "art",
         "evm"
-      ]
-    },
-    {
-      "name": "DOTNIGHT - TOKEN2049",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/DotNight.svg",
-      "url": "https://dotnight.unique.network/",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "Vortex Finance",
-      "url": "https://app.vortexfinance.co/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Vortex.png",
-      "categories": [
-        "evm",
-        "utilities"
-      ]
-    },
-    {
-      "name": "Centrifuge CFG Migration App",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Centrifuge.svg",
-      "url": "https://app.centrifuge.io/#/portfolio/migrate/cent",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Polkadot Pop-Up Summer",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/PolkadotSummer.png",
-      "url": "https://popupsummer.unique.network/",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "RFP Launcher",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/rfp-launcher.svg",
-      "url": "https://rfp.fund/",
-      "categories": [
-        "governance"
-      ]
-    },
-    {
-      "name": "Unique Staking",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Unique_Staking.svg",
-      "url": "https://unique.network/staking",
-      "categories": [
-        "staking"
       ]
     },
     {
@@ -751,38 +220,12 @@
       ]
     },
     {
-      "name": "Mixocracy",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Mixocracy.svg",
-      "url": "https://www.mixocracy.xyz/",
-      "categories": [
-        "utilities",
-        "governance"
-      ]
-    },
-    {
-      "name": "Chaotic",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Chaotic.svg",
-      "url": "https://chaotic.art/",
-      "categories": [
-        "art"
-      ]
-    },
-    {
       "name": "WUD Universe",
       "url": "https://wuduniverse.xyz/",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/WudUniverse.png",
       "categories": [
         "gaming",
         "social"
-      ]
-    },
-    {
-      "name": "dotID",
-      "url": "https://dotid.app",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/dotID.svg",
-      "categories": [
-        "social",
-        "utilities"
       ]
     },
     {

--- a/dapps/dapps_dev.json
+++ b/dapps/dapps_dev.json
@@ -10,22 +10,7 @@
       "url": "https://app.snowbridge.network/"
     },
     {
-      "url": "https://flappywud.lol/"
-    },
-    {
-      "url": "https://kodadot.xyz/"
-    },
-    {
       "url": "https://polkadot.subsquare.io/"
-    },
-    {
-      "url": "https://polkadot.polkassembly.io/"
-    },
-    {
-      "url": "https://play.chessonchain.io"
-    },
-    {
-      "url": "https://app.phala.network/"
     },
     {
       "url": "https://portal.astar.network/"
@@ -38,12 +23,6 @@
     },
     {
       "url": "https://app.hyperbridge.network/"
-    },
-    {
-      "url": "https://app.mimir.global/welcome?network=polkadot"
-    },
-    {
-      "url": "https://dotmemo.xyz/"
     }
   ],
   "categories": [
@@ -115,14 +94,6 @@
       ]
     },
     {
-      "name": "Phala App",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Phala.svg",
-      "url": "https://app.phala.network/",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
       "name": "Hyperbridge",
       "url": "https://app.hyperbridge.network/",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Hyperbridge.svg",
@@ -157,160 +128,12 @@
       ]
     },
     {
-      "name": "Moonbeam App",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Moonbeam.svg",
-      "url": "https://apps.moonbeam.network/moonbeam",
-      "categories": [
-        "staking",
-        "utilities",
-        "evm"
-      ]
-    },
-    {
-      "name": "Stellaswap",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/StellaSwap.svg",
-      "url": "https://app.stellaswap.com/exchange/swap",
-      "categories": [
-        "bridge",
-        "dex",
-        "evm"
-      ]
-    },
-    {
-      "name": "Polkassembly",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Polkassembly.svg",
-      "url": "https://polkadot.polkassembly.io/",
-      "categories": [
-        "governance"
-      ]
-    },
-    {
       "name": "Subsquare",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/SubSquare.svg",
       "url": "https://polkadot.subsquare.io/",
       "categories": [
         "governance"
       ]
-    },
-    {
-      "name": "KodaDot",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/KodaDot.svg",
-      "url": "https://kodadot.xyz/",
-      "categories": [
-        "art"
-      ]
-    },
-    {
-      "name": "Singular",
-      "url": "https://singular.app/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Singular.svg",
-      "categories": [
-        "art"
-      ]
-    },
-    {
-      "name": "Dotmemo",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/.MEMO.svg",
-      "url": "https://dotmemo.xyz/",
-      "categories": [
-        "art",
-        "social",
-        "gaming"
-      ]
-    },
-    {
-      "name": "Raresama",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Raresama.svg",
-      "url": "https://raresama.com/",
-      "categories": [
-        "art",
-        "evm"
-      ]
-    },
-    {
-      "name": "Proof of Chaos",
-      "url": "https://www.proofofchaos.app/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Proof_of_Chaos.svg",
-      "categories": [
-        "art",
-        "governance"
-      ]
-    },
-    {
-      "name": "FlappyWUD",
-      "url": "https://flappywud.lol/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/FlappyWUD.png",
-      "categories": [
-        "gaming"
-      ]
-    },
-    {
-      "name": "ChessOnChain",
-      "url": "https://play.chessonchain.io",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/ChessOnChain.svg",
-      "categories": [
-        "gaming"
-      ]
-    },
-    {
-      "name": "Skybreach",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Skybreach.png",
-      "url": "https://skybreach.app/",
-      "categories": [
-        "evm",
-        "gaming"
-      ]
-    },
-    {
-      "name": "Grill",
-      "url": "https://grillapp.net/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Grill.svg",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "Sub.ID",
-      "url": "https://sub.id/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Sub.ID.svg",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Dotmarketcap",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Dotmarketcap.svg",
-      "url": "https://dotmarketcap.com/",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "Kintsugi Hub",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Kintsugi.svg",
-      "url": "https://kintsugi.interlay.io/",
-      "categories": [
-        "bridge",
-        "staking"
-      ]
-    },
-    {
-      "name": "Karura App (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Karura.svg",
-      "url": "https://apps.karura.network/",
-      "categories": [
-        "staking"
-      ],
-      "desktopOnly": true
-    },
-    {
-      "name": "KILT Stakeboard (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Kilt.svg",
-      "url": "https://stakeboard.kilt.io/",
-      "categories": [
-        "staking"
-      ],
-      "desktopOnly": true
     },
     {
       "name": "Robonomics",
@@ -330,41 +153,6 @@
       ]
     },
     {
-      "name": "cBRIDGE",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/cBRIDGE.svg",
-      "url": "https://cbridge.celer.network/",
-      "categories": [
-        "dex",
-        "evm"
-      ]
-    },
-    {
-      "name": "XDAO",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/XDAO.svg",
-      "url": "https://www.xdao.app/1284",
-      "categories": [
-        "bridge",
-        "dex",
-        "evm"
-      ]
-    },
-    {
-      "name": "Darwinia Portal",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Darwinia.svg",
-      "url": "https://apps.darwinia.network/",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Polkawatch",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Polkawatch.svg",
-      "url": "https://polkawatch.app/",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
       "name": "Polkadot Staking Dashboard",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/StakingDashboard.svg",
       "url": "https://staking.polkadot.cloud/#/overview",
@@ -374,116 +162,12 @@
       ]
     },
     {
-      "name": "Moonsama",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Moonsama.svg",
-      "url": "https://marketplace.moonsama.com/",
-      "categories": [
-        "art",
-        "evm"
-      ]
-    },
-    {
       "name": "Basilisk Snek Swap",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/SnekSwap.svg",
-      "url": "https://app.basilisk.cloud/trade",
+      "url": "https://app.basilisk.cloud/",
       "categories": [
         "bridge",
         "dex"
-      ]
-    },
-    {
-      "name": "Zeitgeist",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Zeitgeist.svg",
-      "url": "https://app.zeitgeist.pm/",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Polkadex Orderbook",
-      "url": "https://orderbook.polkadex.trade/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Polkadex.svg",
-      "categories": [
-        "dex",
-        "utilities"
-      ]
-    },
-    {
-      "name": "Interlay Bitcoin DeFi Hub",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Interlay.svg",
-      "url": "https://app.interlay.io/",
-      "categories": [
-        "bridge",
-        "staking"
-      ]
-    },
-    {
-      "name": "xx network Hub",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/xx.svg",
-      "url": "https://hub.xx.network/",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Acala App (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Acala.svg",
-      "url": "https://apps.acala.network/",
-      "categories": [
-        "staking"
-      ],
-      "desktopOnly": true
-    },
-    {
-      "name": "Zenlink",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Zenlink.svg",
-      "url": "https://app.zenlink.pro",
-      "categories": [
-        "dex"
-      ]
-    },
-    {
-      "name": "Secret Stash",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Secret_stash.png",
-      "url": "https://secret-stash.io/",
-      "categories": [
-        "art"
-      ]
-    },
-    {
-      "name": "GIANTProtocol",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Giant.svg",
-      "url": "https://app.giantprotocol.org/shop",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Pendulum Chain Portal",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Pendulum.svg",
-      "url": "https://portal.pendulumchain.org/pendulum/dashboard",
-      "categories": [
-        "utilities",
-        "staking"
-      ]
-    },
-    {
-      "name": "Awesome Ajuna Avatars (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/AwesomeAjunaAvatars.svg",
-      "url": "https://aaa.ajuna.io/",
-      "categories": [
-        "art",
-        "gaming"
-      ],
-      "desktopOnly": true
-    },
-    {
-      "name": "Big Ballz of Bajun",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/BigBallzOfBajun.png",
-      "url": "https://bbb.ajuna.io/",
-      "categories": [
-        "art",
-        "gaming"
       ]
     },
     {
@@ -506,91 +190,9 @@
       ]
     },
     {
-      "name": "AZERO.ID",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/AzeroID.svg",
-      "url": "https://azero.id/dashboard",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Omni Liquid Staking",
-      "url": "https://omni.ls/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/OmniLS.svg",
-      "categories": [
-        "staking",
-        "evm"
-      ]
-    },
-    {
-      "name": "Joystream Governance App",
-      "url": "https://pioneerapp.xyz/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Pioneer.svg",
-      "categories": [
-        "governance"
-      ]
-    },
-    {
-      "name": "Gleev",
-      "url": "https://gleev.xyz/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Gleev.svg",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "InvArch Dashboard",
-      "url": "https://portal.invarch.network/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/InvArch.svg",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
-      "name": "Ternoa HUB",
-      "url": "https://hub.ternoa.network/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Ternoa.png",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
-      "name": "Capital Curio",
-      "url": "https://capitaldex.exchange/staking",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/CapitalDEX.svg",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
-      "name": "Polymesh Portal",
-      "url": "https://portal.polymesh.network/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Polymesh.png",
-      "categories": [
-        "utilities",
-        "staking"
-      ]
-    },
-    {
-      "name": "Battleship",
-      "url": "https://battleship.vara.network/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Battleship.svg",
-      "categories": [
-        "gaming"
-      ]
-    },
-    {
       "name": "Taostats",
-      "url": "https://dash.taostats.io/",
+      "url": "https://taostats.io",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Taostats.svg",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
-      "name": "Mentat Minds",
-      "url": "https://mentatminds.com/delegate/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/MentatMinds.svg",
       "categories": [
         "staking"
       ]
@@ -602,23 +204,6 @@
       "categories": [
         "utilities",
         "test"
-      ]
-    },
-    {
-      "name": "Nodle client",
-      "url": "https://client.nodle.com/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/NodleClient.svg",
-      "categories": [
-        "utilities"
-      ],
-      "desktopOnly": true
-    },
-    {
-      "name": "Incognitee Privacy Sidechains Dapp",
-      "url": "https://app.incognitee.io/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Incognitee.svg",
-      "categories": [
-        "utilities"
       ]
     },
     {
@@ -649,128 +234,12 @@
       ]
     },
     {
-      "name": "Aleph Zero MOST",
-      "url": "https://mo.st/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Most.svg",
-      "categories": [
-        "bridge",
-        "dex"
-      ]
-    },
-    {
-      "name": "Euphrates (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Euphrates.svg",
-      "url": "https://farm.acala.network/",
-      "categories": [
-        "staking"
-      ],
-      "desktopOnly": true
-    },
-    {
-      "name": "Mimir",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Mimir.svg",
-      "url": "https://app.mimir.global/welcome?network=polkadot",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "AirLyft Campaigns",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/AirLyft.svg",
-      "url": "https://airlyft.one/",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "Unique PlayX",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Unique-playX.svg",
-      "url": "https://playx.unique.network",
-      "categories": [
-        "gaming"
-      ]
-    },
-    {
-      "name": "Unique Marketplace",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Unique.svg",
-      "url": "https://unqnft.io",
-      "categories": [
-        "gaming",
-        "art"
-      ]
-    },
-    {
-      "name": "Unlock Polkadot",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Unlockpolkadot.svg",
-      "url": "https://unlockpolkadot.com",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "DOT Yappers",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Dotyappers.png",
-      "url": "https://dotyappers.com",
-      "categories": [
-        "social"
-      ]
-    },
-    {
       "name": "OpenSea",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/OpenSea.svg",
       "url": "https://opensea.io/",
       "categories": [
         "art",
         "evm"
-      ]
-    },
-    {
-      "name": "DOTNIGHT - TOKEN2049",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/DotNight.svg",
-      "url": "https://dotnight.unique.network/",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "Vortex Finance",
-      "url": "https://app.vortexfinance.co/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Vortex.png",
-      "categories": [
-        "evm",
-        "utilities"
-      ]
-    },
-    {
-      "name": "Centrifuge CFG Migration App",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Centrifuge.svg",
-      "url": "https://app.centrifuge.io/#/portfolio/migrate/cent",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Polkadot Pop-Up Summer",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/PolkadotSummer.png",
-      "url": "https://popupsummer.unique.network/",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "RFP Launcher",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/rfp-launcher.svg",
-      "url": "https://rfp.fund/",
-      "categories": [
-        "governance"
-      ]
-    },
-    {
-      "name": "Unique Staking",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Unique_Staking.svg",
-      "url": "https://unique.network/staking",
-      "categories": [
-        "staking"
       ]
     },
     {
@@ -820,15 +289,6 @@
       ]
     },
     {
-      "name": "Mixocracy",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Mixocracy.svg",
-      "url": "https://www.mixocracy.xyz/",
-      "categories": [
-        "utilities",
-        "governance"
-      ]
-    },
-    {
       "name": "V-Starship",
       "url": "https://starship.vara.network/",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/VStarshipFav.png",
@@ -855,29 +315,12 @@
       ]
     },
     {
-      "name": "Chaotic",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Chaotic.svg",
-      "url": "https://chaotic.art/",
-      "categories": [
-        "art"
-      ]
-    },
-    {
       "name": "WUD Universe",
       "url": "https://wuduniverse.xyz/",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/WudUniverse.png",
       "categories": [
         "gaming",
         "social"
-      ]
-    },
-    {
-      "name": "dotID",
-      "url": "https://dotid.app",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/dotID.svg",
-      "categories": [
-        "social",
-        "utilities"
       ]
     }
   ]

--- a/dapps/dapps_full.json
+++ b/dapps/dapps_full.json
@@ -10,22 +10,7 @@
       "url": "https://app.snowbridge.network/"
     },
     {
-      "url": "https://flappywud.lol/"
-    },
-    {
-      "url": "https://kodadot.xyz/"
-    },
-    {
       "url": "https://polkadot.subsquare.io/"
-    },
-    {
-      "url": "https://polkadot.polkassembly.io/"
-    },
-    {
-      "url": "https://play.chessonchain.io"
-    },
-    {
-      "url": "https://app.phala.network/"
     },
     {
       "url": "https://portal.astar.network/"
@@ -38,12 +23,6 @@
     },
     {
       "url": "https://app.hyperbridge.network/"
-    },
-    {
-      "url": "https://app.mimir.global/welcome?network=polkadot"
-    },
-    {
-      "url": "https://dotmemo.xyz/"
     }
   ],
   "categories": [
@@ -111,14 +90,6 @@
       ]
     },
     {
-      "name": "Phala App",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Phala.svg",
-      "url": "https://app.phala.network/",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
       "name": "Hyperbridge",
       "url": "https://app.hyperbridge.network/",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Hyperbridge.svg",
@@ -153,34 +124,6 @@
       ]
     },
     {
-      "name": "Moonbeam App",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Moonbeam.svg",
-      "url": "https://apps.moonbeam.network/moonbeam",
-      "categories": [
-        "staking",
-        "utilities",
-        "evm"
-      ]
-    },
-    {
-      "name": "Stellaswap",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/StellaSwap.svg",
-      "url": "https://app.stellaswap.com/exchange/swap",
-      "categories": [
-        "bridge",
-        "dex",
-        "evm"
-      ]
-    },
-    {
-      "name": "Polkassembly",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Polkassembly.svg",
-      "url": "https://polkadot.polkassembly.io/",
-      "categories": [
-        "governance"
-      ]
-    },
-    {
       "name": "Subsquare",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/SubSquare.svg",
       "url": "https://polkadot.subsquare.io/",
@@ -189,150 +132,12 @@
       ]
     },
     {
-      "name": "KodaDot",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/KodaDot.svg",
-      "url": "https://kodadot.xyz/",
-      "categories": [
-        "art"
-      ]
-    },
-    {
-      "name": "Singular",
-      "url": "https://singular.app/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Singular.svg",
-      "categories": [
-        "art"
-      ]
-    },
-    {
-      "name": "Dotmemo",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/.MEMO.svg",
-      "url": "https://dotmemo.xyz/",
-      "categories": [
-        "art",
-        "social",
-        "gaming"
-      ]
-    },
-    {
-      "name": "Raresama",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Raresama.svg",
-      "url": "https://raresama.com/",
-      "categories": [
-        "art",
-        "evm"
-      ]
-    },
-    {
-      "name": "Proof of Chaos",
-      "url": "https://www.proofofchaos.app/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Proof_of_Chaos.svg",
-      "categories": [
-        "art",
-        "governance"
-      ]
-    },
-    {
-      "name": "FlappyWUD",
-      "url": "https://flappywud.lol/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/FlappyWUD.png",
-      "categories": [
-        "gaming"
-      ]
-    },
-    {
-      "name": "ChessOnChain",
-      "url": "https://play.chessonchain.io",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/ChessOnChain.svg",
-      "categories": [
-        "gaming"
-      ]
-    },
-    {
-      "name": "Skybreach",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Skybreach.png",
-      "url": "https://skybreach.app/",
-      "categories": [
-        "evm",
-        "gaming"
-      ]
-    },
-    {
-      "name": "Grill",
-      "url": "https://grillapp.net/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Grill.svg",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "Sub.ID",
-      "url": "https://sub.id/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Sub.ID.svg",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Dotmarketcap",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Dotmarketcap.svg",
-      "url": "https://dotmarketcap.com/",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "Kintsugi Hub",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Kintsugi.svg",
-      "url": "https://kintsugi.interlay.io/",
-      "categories": [
-        "bridge",
-        "staking"
-      ]
-    },
-    {
-      "name": "Karura App (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Karura.svg",
-      "url": "https://apps.karura.network/",
-      "categories": [
-        "staking"
-      ],
-      "desktopOnly": true
-    },
-    {
       "name": "ArthSwap",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/ArthSwap.svg",
       "url": "https://app.arthswap.org/#/swap",
       "categories": [
         "dex",
         "evm"
-      ]
-    },
-    {
-      "name": "cBRIDGE",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/cBRIDGE.svg",
-      "url": "https://cbridge.celer.network/",
-      "categories": [
-        "dex",
-        "evm"
-      ]
-    },
-    {
-      "name": "XDAO",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/XDAO.svg",
-      "url": "https://www.xdao.app/1284",
-      "categories": [
-        "bridge",
-        "dex",
-        "evm"
-      ]
-    },
-    {
-      "name": "Polkawatch",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Polkawatch.svg",
-      "url": "https://polkawatch.app/",
-      "categories": [
-        "utilities"
       ]
     },
     {
@@ -345,114 +150,12 @@
       ]
     },
     {
-      "name": "Moonsama",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Moonsama.svg",
-      "url": "https://marketplace.moonsama.com/",
-      "categories": [
-        "art",
-        "evm"
-      ]
-    },
-    {
-      "name": "Darwinia Portal",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Darwinia.svg",
-      "url": "https://apps.darwinia.network/",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
       "name": "Basilisk Snek Swap",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/SnekSwap.svg",
-      "url": "https://app.basilisk.cloud/trade",
+      "url": "https://app.basilisk.cloud/",
       "categories": [
         "bridge",
         "dex"
-      ]
-    },
-    {
-      "name": "Zeitgeist",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Zeitgeist.svg",
-      "url": "https://app.zeitgeist.pm/",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Polkadex Orderbook",
-      "url": "https://orderbook.polkadex.trade/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Polkadex.svg",
-      "categories": [
-        "dex",
-        "utilities"
-      ]
-    },
-    {
-      "name": "Interlay Bitcoin DeFi Hub",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Interlay.svg",
-      "url": "https://app.interlay.io/",
-      "categories": [
-        "bridge",
-        "staking"
-      ]
-    },
-    {
-      "name": "xx network Hub",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/xx.svg",
-      "url": "https://hub.xx.network/",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Acala App (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Acala.svg",
-      "url": "https://apps.acala.network/",
-      "categories": [
-        "staking"
-      ],
-      "desktopOnly": true
-    },
-    {
-      "name": "Zenlink",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Zenlink.svg",
-      "url": "https://app.zenlink.pro",
-      "categories": [
-        "dex"
-      ]
-    },
-    {
-      "name": "KILT Stakeboard (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Kilt.svg",
-      "url": "https://stakeboard.kilt.io/",
-      "categories": [
-        "staking"
-      ],
-      "desktopOnly": true
-    },
-    {
-      "name": "Secret Stash",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Secret_stash.png",
-      "url": "https://secret-stash.io/",
-      "categories": [
-        "art"
-      ]
-    },
-    {
-      "name": "GIANTProtocol",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Giant.svg",
-      "url": "https://app.giantprotocol.org/shop",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Pendulum Chain Portal",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Pendulum.svg",
-      "url": "https://portal.pendulumchain.org/pendulum/dashboard",
-      "categories": [
-        "utilities",
-        "staking"
       ]
     },
     {
@@ -464,16 +167,6 @@
       ]
     },
     {
-      "name": "Awesome Ajuna Avatars (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/AwesomeAjunaAvatars.svg",
-      "url": "https://aaa.ajuna.io/",
-      "categories": [
-        "art",
-        "gaming"
-      ],
-      "desktopOnly": true
-    },
-    {
       "name": "Tensor Wallet",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/TensorWallet.svg",
       "url": "https://tensorwallet.ca/",
@@ -483,186 +176,11 @@
       ]
     },
     {
-      "name": "AZERO.ID",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/AzeroID.svg",
-      "url": "https://azero.id/dashboard",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Omni Liquid Staking",
-      "url": "https://omni.ls/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/OmniLS.svg",
-      "categories": [
-        "staking",
-        "evm"
-      ]
-    },
-    {
-      "name": "Joystream Governance App",
-      "url": "https://pioneerapp.xyz/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Pioneer.svg",
-      "categories": [
-        "governance"
-      ]
-    },
-    {
-      "name": "Gleev",
-      "url": "https://gleev.xyz/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Gleev.svg",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "InvArch Dashboard",
-      "url": "https://portal.invarch.network/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/InvArch.svg",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
-      "name": "Ternoa HUB",
-      "url": "https://hub.ternoa.network/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Ternoa.png",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
-      "name": "Capital Curio",
-      "url": "https://capitaldex.exchange/staking",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/CapitalDEX.svg",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
-      "name": "Polymesh Portal",
-      "url": "https://portal.polymesh.network/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Polymesh.png",
-      "categories": [
-        "utilities",
-        "staking"
-      ]
-    },
-    {
-      "name": "Battleship",
-      "url": "https://battleship.vara.network/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Battleship.svg",
-      "categories": [
-        "gaming"
-      ]
-    },
-    {
       "name": "Taostats",
-      "url": "https://dash.taostats.io/",
+      "url": "https://taostats.io",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Taostats.svg",
       "categories": [
         "staking"
-      ]
-    },
-    {
-      "name": "Big Ballz of Bajun",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/BigBallzOfBajun.png",
-      "url": "https://bbb.ajuna.io/",
-      "categories": [
-        "art",
-        "gaming"
-      ]
-    },
-    {
-      "name": "Mentat Minds",
-      "url": "https://mentatminds.com/delegate/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/MentatMinds.svg",
-      "categories": [
-        "staking"
-      ]
-    },
-    {
-      "name": "Nodle client",
-      "url": "https://client.nodle.com/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/NodleClient.svg",
-      "categories": [
-        "utilities"
-      ],
-      "desktopOnly": true
-    },
-    {
-      "name": "Incognitee Privacy Sidechains Dapp",
-      "url": "https://app.incognitee.io/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Incognitee.svg",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Aleph Zero MOST",
-      "url": "https://mo.st/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Most.svg",
-      "categories": [
-        "bridge",
-        "dex"
-      ]
-    },
-    {
-      "name": "Euphrates (Desktop mode)",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Euphrates.svg",
-      "url": "https://farm.acala.network/",
-      "categories": [
-        "staking"
-      ],
-      "desktopOnly": true
-    },
-    {
-      "name": "Mimir",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Mimir.svg",
-      "url": "https://app.mimir.global/welcome?network=polkadot",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "AirLyft Campaigns",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/AirLyft.svg",
-      "url": "https://airlyft.one/",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "Unique PlayX",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Unique-playX.svg",
-      "url": "https://playx.unique.network",
-      "categories": [
-        "gaming"
-      ]
-    },
-    {
-      "name": "Unique Marketplace",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Unique.svg",
-      "url": "https://unqnft.io",
-      "categories": [
-        "gaming",
-        "art"
-      ]
-    },
-    {
-      "name": "Unlock Polkadot",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Unlockpolkadot.svg",
-      "url": "https://unlockpolkadot.com",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "DOT Yappers",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Dotyappers.png",
-      "url": "https://dotyappers.com",
-      "categories": [
-        "social"
       ]
     },
     {
@@ -672,55 +190,6 @@
       "categories": [
         "art",
         "evm"
-      ]
-    },
-    {
-      "name": "DOTNIGHT - TOKEN2049",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/DotNight.svg",
-      "url": "https://dotnight.unique.network/",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "Vortex Finance",
-      "url": "https://app.vortexfinance.co/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Vortex.png",
-      "categories": [
-        "evm",
-        "utilities"
-      ]
-    },
-    {
-      "name": "Centrifuge CFG Migration App",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Centrifuge.svg",
-      "url": "https://app.centrifuge.io/#/portfolio/migrate/cent",
-      "categories": [
-        "utilities"
-      ]
-    },
-    {
-      "name": "Polkadot Pop-Up Summer",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/PolkadotSummer.png",
-      "url": "https://popupsummer.unique.network/",
-      "categories": [
-        "social"
-      ]
-    },
-    {
-      "name": "RFP Launcher",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/rfp-launcher.svg",
-      "url": "https://rfp.fund/",
-      "categories": [
-        "governance"
-      ]
-    },
-    {
-      "name": "Unique Staking",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Unique_Staking.svg",
-      "url": "https://unique.network/staking",
-      "categories": [
-        "staking"
       ]
     },
     {
@@ -751,38 +220,12 @@
       ]
     },
     {
-      "name": "Mixocracy",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Mixocracy.svg",
-      "url": "https://www.mixocracy.xyz/",
-      "categories": [
-        "utilities",
-        "governance"
-      ]
-    },
-    {
-      "name": "Chaotic",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/Chaotic.svg",
-      "url": "https://chaotic.art/",
-      "categories": [
-        "art"
-      ]
-    },
-    {
       "name": "WUD Universe",
       "url": "https://wuduniverse.xyz/",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/WudUniverse.png",
       "categories": [
         "gaming",
         "social"
-      ]
-    },
-    {
-      "name": "dotID",
-      "url": "https://dotid.app",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/dotID.svg",
-      "categories": [
-        "social",
-        "utilities"
       ]
     },
     {


### PR DESCRIPTION
## What

Removes **63 of 82** dapps from the dApp browser list and fixes **2 URLs** on entries we keep, leaving **19**.

Applied to `dapps.json`, `dapps_full.json` and `dapps_dev.json`. Dev-only entries in `dapps_dev.json` are untouched (9 remain).

## Why

The list has accumulated entries whose chains no longer produce blocks, whose domains no longer resolve, or whose projects have left Polkadot. Several of these still return HTTP 200, so they look fine in a browser while being impossible to transact on — a user can open them from the wallet, connect, and get nothing.

Every entry was verified rather than eyeballed:

1. HTTP + DNS sweep of all 82 URLs (status, redirect target, page title, A-record).
2. Chain liveness read off the relay chains — `Paras::Heads` sampled repeatedly per parachain, so a chain is only called dead if its head genuinely stopped advancing (Hydration advanced +42 blocks in the same window the dead ones moved zero, as a control).
3. Usage measured over a contiguous 24h window: signed extrinsics per block with inherents excluded, and signer addresses decoded to count distinct daily actors. EVM traffic counted separately via `eth_` RPC, since `ethereum.transact` is unsigned and invisible to extrinsic counting.
4. TVL / DEX volume cross-checked against DefiLlama.

### Chains that have stopped producing blocks

| Chain | Evidence |
| --- | --- |
| Interlay (DOT 2032) | head frozen at 10,885,373, last block ~10 days prior |
| Kintsugi (KSM 2092) | halted at the same time as Interlay |
| Phala (DOT 2035) | head frozen at 9,064,613, all public RPCs unreachable |
| Zeitgeist (DOT 2092) | head frozen at 9,989,460 |
| KILT (DOT 2086) | head frozen at 10,172,610 |
| Nodle (DOT 2026) | head frozen at 8,818,067 |
| Centrifuge (DOT 2031) | head frozen at 9,806,878 |
| Bajun, Subsocial, Exosama, Amplitude | heads frozen, no advance |
| Integritee (KSM 2015) | no head entry on the relay — deregistered |

Interlay, Kintsugi, Phala, Zeitgeist and Nodle all still serve HTTP 200. These are the actively misleading ones.

### Projects that have left Polkadot

- **Moonbeam** — `apps.moonbeam.network/moonbeam` redirects to the forum post "Moonbeam relaunches on Base"; our own `chains.json` already tags Moonbeam `(PAUSED)`.
- **StellaSwap** — redirects to a page titled "StellaSwap — Sunset".
- **Ternoa (Secret Stash)** — redirects to "Ternoa — The Web3 Security Toolkit on Base".
- **Centrifuge** — the listed entry is the CFG migration tool; the parachain has since halted.

### Dead front-ends

- **NXDOMAIN:** proofofchaos.app, grillapp.net, sub.id, orderbook.polkadex.trade, stakeboard.kilt.io, aaa.ajuna.io, portal.invarch.network
- **HTTP 402 (host suspended):** dotmarketcap.com, gleev.xyz, pioneerapp.xyz, hub.ternoa.network

### Usage

Distinct signing addresses over 24h, by chain:

| Chain | Txns/24h | Distinct addresses |
| --- | --- | --- |
| Bittensor | 109,745 | 5,978 |
| Polkadot Asset Hub | 10,136 | 739 |
| Bridge Hub (Snowbridge) | 2,794 | 6 relayers |
| Astar | 256 + 2,487 EVM | 109 + 52 |
| Hydration | 1,588 + 167 EVM | 96 |
| Acala | 1,042 + 14 EVM | 34 |
| Karura | 485 | 9 |
| Darwinia | 0 + 56 EVM | 6 |
| Pendulum | 3 | 1 |
| Unique | 1 + 1 EVM | 1 |
| Curio | 0 | 0 |

Karura Swap holds $0 TVL and did $16 of volume in 24h; Acala Swap also reports $0 TVL. Hydration DEX, by contrast, does $1.88M/24h on $24.6M TVL.

## URL fixes

| dApp | Before | After |
| --- | --- | --- |
| Basilisk Snek Swap | `app.basilisk.cloud/trade` (404) | `https://app.basilisk.cloud/` (200) |
| Taostats | `dash.taostats.io` (redirects to paid Pro login) | `https://taostats.io` (200) |

## Popular carousel

7 of the removed entries were in `popular`, so it goes from 15 to 8 entries: flappywud, kodadot, polkassembly, chessonchain, phala, mimir and dotmemo are dropped. **It is worth backfilling** — please shout if you want specific entries promoted.

## Notes for reviewers

- **`dapps/README.md` is intentionally not touched** — the `update_network_list` workflow regenerates it from `dapps_full.json` and raises its own follow-up PR, as it did in #4341.
- **`https://ramp.harbour.fi/polkadot` is left as-is.** It sits in `popular` but has **no entry in `dapps[]`** — a pre-existing dangling reference, unrelated to this cleanup. Either it needs a catalogue entry or it should be dropped; flagging rather than deciding it here.
- **Category counts after this change:** Staking 8, Utilities 7, DEX 5, Bridge 4, EVM 3, Governance 2, and Art 1, Gaming 1, Social 1. Those last three will look thin in the UI — worth deciding whether to hide the filters or source replacements.
- **Multisig:** Mimir is removed here; `dapps_dev.json` already carries **Signet** (`polkadotmultisig.com`), and there is an open community PR #3302 adding it to the main list.
- **This will conflict with open dapp-adding PRs** that touch the same files — #4360 (Stakao), #4356 (Gavun's Grid Miner), #4347 (The Wudlands), #4032 (FintraDEX), #3302 (Signet), #2687 (passief-income). Merge order matters; happy to rebase whichever way suits.
- Icon files for removed dapps are left in `icons/dapps/` — no validation depends on them, and removing them can be a separate cleanup if wanted.
