### PR TITLE
feat: remove governance support from 15 networks, fix Bifrost Polkadot api

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -1010,9 +1010,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Karura.svg",
         "addressPrefix": 8,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "feeViaRuntimeCall": true,
             "supportsGenericLedgerApp": true
@@ -1362,7 +1359,6 @@
         "addressPrefix": 1284,
         "options": [
             "ethereumBased",
-            "governance",
             "proxy",
             "multisig"
         ],
@@ -1793,7 +1789,6 @@
         "addressPrefix": 1285,
         "options": [
             "ethereumBased",
-            "governance",
             "proxy"
         ],
         "additional": {
@@ -2335,9 +2330,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Basilisk.svg",
         "addressPrefix": 10041,
-        "options": [
-            "governance-v1"
-        ],
         "types": {
             "url": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/chains/v2/types/basilisk.json",
             "overridesCommon": true
@@ -2382,9 +2374,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Altair.svg",
         "addressPrefix": 136,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "feeViaRuntimeCall": true,
             "disabledCheckMetadataHash": true
@@ -2469,9 +2458,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/KILT_Spiritnet.svg",
         "addressPrefix": 38,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "supportsGenericLedgerApp": true
         }
@@ -2789,10 +2775,7 @@
         "additional": {
             "feeViaRuntimeCall": true,
             "supportsGenericLedgerApp": true
-        },
-        "options": [
-            "governance-v1"
-        ]
+        }
     },
     {
         "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
@@ -3461,9 +3444,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Robonomics.svg",
         "addressPrefix": 32,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "feeViaRuntimeCall": true
         }
@@ -3831,9 +3811,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Zeitgeist.svg",
         "addressPrefix": 73,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "themeColor": "#1F78FF",
             "stakingWiki": "https://docs.novawallet.io/nova-wallet-wiki/staking/zeitgeist-ztg-staking",
@@ -4006,9 +3983,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Centrifuge.svg",
         "addressPrefix": 36,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "feeViaRuntimeCall": true,
             "disabledCheckMetadataHash": true
@@ -5084,7 +5058,6 @@
         "addressPrefix": 0,
         "options": [
             "governance",
-            "governance-v1",
             "hydradx-swaps",
             "hydration-fees",
             "proxy",
@@ -5418,9 +5391,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Phala.svg",
         "addressPrefix": 30,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "supportsGenericLedgerApp": true
         }
@@ -5636,9 +5606,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Polkadex.svg",
         "addressPrefix": 88,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "themeColor": "#1F78FF",
             "stakingWiki": "https://docs.novawallet.io/nova-wallet-wiki/staking/polkadex-pdex-staking",
@@ -5899,7 +5866,7 @@
             "governance": [
                 {
                     "type": "subsquare",
-                    "url": "https://bifrost.subsquare.io/api"
+                    "url": "https://bifrost-api.subsquare.io"
                 }
             ]
         },
@@ -6818,9 +6785,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Pendulum.svg",
         "addressPrefix": 0,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "supportsGenericLedgerApp": true
         },
@@ -8009,7 +7973,6 @@
         "addressPrefix": 29972,
         "options": [
             "ethereumBased",
-            "governance-v1",
             "proxy",
             "multisig"
         ],

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -1016,9 +1016,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Karura.svg",
         "addressPrefix": 8,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "feeViaRuntimeCall": true,
             "supportsGenericLedgerApp": true
@@ -1355,7 +1352,6 @@
         "addressPrefix": 1285,
         "options": [
             "ethereumBased",
-            "governance",
             "proxy",
             "multisig"
         ],
@@ -2212,9 +2208,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Basilisk.svg",
         "addressPrefix": 10041,
-        "options": [
-            "governance-v1"
-        ],
         "types": {
             "url": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/chains/v2/types/basilisk.json",
             "overridesCommon": true
@@ -2259,9 +2252,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Altair.svg",
         "addressPrefix": 136,
-        "options": [
-            "governance"
-        ],
         "additional": {
             "feeViaRuntimeCall": true,
             "disabledCheckMetadataHash": true
@@ -2317,9 +2307,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/KILT_Spiritnet.svg",
         "addressPrefix": 38,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "supportsGenericLedgerApp": true
         }
@@ -2671,10 +2658,7 @@
         "additional": {
             "feeViaRuntimeCall": true,
             "supportsGenericLedgerApp": true
-        },
-        "options": [
-            "governance-v1"
-        ]
+        }
     },
     {
         "chainId": "23fc729c2cdb7bd6770a4e8c58748387cc715fcf338f1f74a16833d90383f4b0",
@@ -3063,7 +3047,6 @@
         "addressPrefix": 1284,
         "options": [
             "ethereumBased",
-            "governance",
             "proxy",
             "multisig"
         ],
@@ -3936,9 +3919,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Robonomics.svg",
         "addressPrefix": 32,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "feeViaRuntimeCall": true
         }
@@ -4126,9 +4106,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Zeitgeist.svg",
         "addressPrefix": 73,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "themeColor": "#1F78FF",
             "stakingWiki": "https://docs.novawallet.io/nova-wallet-wiki/staking/zeitgeist-ztg-staking",
@@ -4316,9 +4293,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Centrifuge.svg",
         "addressPrefix": 36,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "feeViaRuntimeCall": true,
             "supportsGenericLedgerApp": true
@@ -5394,7 +5368,6 @@
         "addressPrefix": 0,
         "options": [
             "governance",
-            "governance-v1",
             "hydradx-swaps",
             "hydration-fees",
             "proxy",
@@ -5768,9 +5741,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Phala.svg",
         "addressPrefix": 30,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "supportsGenericLedgerApp": true
         }
@@ -6082,9 +6052,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Polkadex.svg",
         "addressPrefix": 88,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "themeColor": "#1F78FF",
             "stakingWiki": "https://docs.novawallet.io/nova-wallet-wiki/staking/polkadex-pdex-staking",
@@ -6346,7 +6313,7 @@
             "governance": [
                 {
                     "type": "subsquare",
-                    "url": "https://bifrost.subsquare.io/api"
+                    "url": "https://bifrost-api.subsquare.io"
                 }
             ]
         },
@@ -7651,9 +7618,6 @@
         },
         "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Pendulum.svg",
         "addressPrefix": 0,
-        "options": [
-            "governance-v1"
-        ],
         "additional": {
             "supportsGenericLedgerApp": true
         },
@@ -9974,7 +9938,6 @@
         "addressPrefix": 29972,
         "options": [
             "ethereumBased",
-            "governance-v1",
             "proxy",
             "multisig"
         ],


### PR DESCRIPTION
Removes the `governance` / `governance-v1` options from 15 networks, so they no
longer appear in the wallet's Vote tab.

After this change the governance network list is 5 entries, all OpenGov:

| Network | Type |
|---|---|
| Polkadot Asset Hub | OpenGov |
| Kusama Asset Hub | OpenGov |
| Hydration | OpenGov |
| Bifrost Polkadot | OpenGov |
| Bifrost Kusama | OpenGov |

### Removed

**OpenGov:** Moonbeam (PAUSED), Moonriver (PAUSED)

**Governance v1:** Acala, Altair, Basilisk, Centrifuge, Hydration, KILT (PAUSED),
Karura, Mythos, Pendulum, Phala, Polkadex, Robonomics, Zeitgeist

Hydration keeps OpenGov and loses only its v1 entry, so it goes from two rows to one.

### Notes

- Robonomics was the last remaining `governance-v1` network in production, and its
  governance API (`polkassembly-hasura.herokuapp.com`) has been returning HTTP 404
  since Heroku retired free dynos — referenda there render without titles or
  discussion links. No production network uses `governance-v1` after this change.
- Both `chains.json` and `chains_dev.json` are updated in this PR rather than
  dev-first-then-promote, so prod and dev stay in step on the same list.
- Altair carried `governance-v1` in prod but `governance` in dev; both are removed.
- Where governance was a network's only option, the now-empty `options` key is
  dropped rather than left as `[]`, matching the 58 networks that already omit it.
- The orphaned `externalApi.governance` blocks are left in place — same state the
  Polkadot/Kusama relays have been in since the Asset Hub migration. Happy to prune
  those and the matching `governance/dapps.json` entries in a follow-up.

### Bifrost Polkadot API fix

Also repoints Bifrost Polkadot's Subsquare API:

```
- https://bifrost.subsquare.io/api   (404 on every documented path)
+ https://bifrost-api.subsquare.io   (200)
```

Subsquare has moved these APIs to a `<chain>-api.subsquare.io` pattern, matching
the hosts Polkadot AH, Kusama AH and Hydration already use. The configured host
returns 404 for `/gov2/referendums` and `/democracy/referendums` alike, so
referendum titles and descriptions are currently missing on Bifrost Polkadot.
Verified the replacement serves the right chain: it reports `total = 299`
against Bifrost Polkadot's on-chain `Referenda.ReferendumCount = 299`.

⚠️ **Bifrost Kusama has the same problem and is not fixed here** — its configured
`bifrost-kusama.subsquare.io/api` also 404s, but no replacement host resolves
(`bifrost-kusama-api`, `bifrostkusama-api`, `kusama-bifrost-api` are all NXDOMAIN)
even though its web UI is up. Needs someone to confirm the correct endpoint with
Subsquare — see the comment below for the full endpoint sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
