### PR TITLE
Add Turing and von Neumann validators to Polkadot Asset Hub

### DIFF
--- a/staking/validators/v1/nova_validators.json
+++ b/staking/validators/v1/nova_validators.json
@@ -38,7 +38,9 @@
       "127zarPDhVzmCXVQ7Kfr1yyaa9wsMuJ74GJW9Q7ezHfQEgh6",
       "13JuwkvSqGUDo8zErgfC9ivGfKfcdDyceFkvh9NW4wz7NbuF",
       "15yWjJfhPwiBECjVezPTA42EFpcrxmRUjzPN6nf3azvZ5wDX",
-      "15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu"
+      "15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu",
+      "151oCCvw1aZS8TZHzvAj6J3zJec7ZLEKRj6FVWhzVGbTXTG1",
+      "16LLBgPW338sbqCkxHpKGpZB9P9y7nnaMSZFodUhpb3bs1H3"
     ]
   },
   "excluded": {

--- a/staking/validators/v1/nova_validators_dev.json
+++ b/staking/validators/v1/nova_validators_dev.json
@@ -38,7 +38,9 @@
       "127zarPDhVzmCXVQ7Kfr1yyaa9wsMuJ74GJW9Q7ezHfQEgh6",
       "13JuwkvSqGUDo8zErgfC9ivGfKfcdDyceFkvh9NW4wz7NbuF",
       "15yWjJfhPwiBECjVezPTA42EFpcrxmRUjzPN6nf3azvZ5wDX",
-      "15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu"
+      "15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu",
+      "151oCCvw1aZS8TZHzvAj6J3zJec7ZLEKRj6FVWhzVGbTXTG1",
+      "16LLBgPW338sbqCkxHpKGpZB9P9y7nnaMSZFodUhpb3bs1H3"
     ]
   },
   "excluded": {


### PR DESCRIPTION
Adds two Novasama validators that were missing from the preferred list on Polkadot Asset Hub:

| Validator | Address |
|---|---|
| `🌌 Novasama 🌌 / Turing` | `151oCCvw1aZS8TZHzvAj6J3zJec7ZLEKRj6FVWhzVGbTXTG1` |
| `🌌 Novasama 🌌 / von Neumann` | `16LLBgPW338sbqCkxHpKGpZB9P9y7nnaMSZFodUhpb3bs1H3` |

Both are sub-identities of the Novasama parent identity `15UHvPeMjYLvMLqh6bWLxAP3MbqjjsMXFWToJKCijzGPM3p9` on Polkadot People, and both are active validators in the current era (verified against `Staking.Validators` and `ErasStakersOverview` on Polkadot Asset Hub).

Applied to both `nova_validators.json` and `nova_validators_dev.json` so the two halves stay in sync.
