### PR TITLE
Move WUD Universe to art category

### DIFF
--- a/dapps/README.md
+++ b/dapps/README.md
@@ -20,4 +20,4 @@
 |  16 | TAOApp                     | https://tao.app/                          | utilities,staking,dex |
 |  17 | Taostats                   | https://taostats.io                       | staking               |
 |  18 | Tensor Wallet              | https://tensorwallet.ca/                  | utilities,staking     |
-|  19 | WUD Universe               | https://wuduniverse.xyz/                  | gaming,social         |
+|  19 | WUD Universe               | https://wuduniverse.xyz/                  | art                   |

--- a/dapps/dapps.json
+++ b/dapps/dapps.json
@@ -224,8 +224,7 @@
       "url": "https://wuduniverse.xyz/",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/WudUniverse.png",
       "categories": [
-        "gaming",
-        "social"
+        "art"
       ]
     },
     {

--- a/dapps/dapps_dev.json
+++ b/dapps/dapps_dev.json
@@ -319,8 +319,7 @@
       "url": "https://wuduniverse.xyz/",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/WudUniverse.png",
       "categories": [
-        "gaming",
-        "social"
+        "art"
       ]
     }
   ]

--- a/dapps/dapps_full.json
+++ b/dapps/dapps_full.json
@@ -224,8 +224,7 @@
       "url": "https://wuduniverse.xyz/",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/WudUniverse.png",
       "categories": [
-        "gaming",
-        "social"
+        "art"
       ]
     },
     {


### PR DESCRIPTION
## What

Change WUD Universe categories from `gaming, social` to `art` in `dapps_dev.json`, `dapps.json` and `dapps_full.json` (README regenerated via `make generate_dapp_list`).

## Why

WUD Universe was the only dapp in both the Gaming and Social categories in prod, so the app rendered two sections each containing just this one dapp. The dapp itself is centered on dynamic NFTs ("build your on-chain cabin with dynamic NFTs"), so `art` fits — it joins OpenSea there, and no single-dapp sections remain.

Dev and prod are changed together intentionally to remove the lonely sections in one step.