### PR TITLE
feat: pause 3 stalled networks and drop unreachable RPC endpoints

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -33,14 +33,6 @@
                 "name": "Stakeworld node"
             },
             {
-                "url": "wss://polkadot.public.curie.radiumblock.co/ws",
-                "name": "Radium node"
-            },
-            {
-                "url": "wss://1rpc.io/dot",
-                "name": "Automata 1RPC node"
-            },
-            {
                 "url": "wss://rpc-polkadot.luckyfriday.io",
                 "name": "LuckyFriday node"
             }
@@ -145,14 +137,6 @@
             {
                 "url": "wss://rpc-kusama.luckyfriday.io",
                 "name": "LuckyFriday node"
-            },
-            {
-                "url": "wss://1rpc.io/ksm",
-                "name": "Automata 1RPC node"
-            },
-            {
-                "url": "wss://kusama.public.curie.radiumblock.co/ws",
-                "name": "Radium node"
             }
         ],
         "explorers": [
@@ -521,10 +505,6 @@
             {
                 "url": "wss://rpc-people-polkadot.luckyfriday.io",
                 "name": "LuckyFriday node"
-            },
-            {
-                "url": "wss://people-polkadot.public.curie.radiumblock.co/ws",
-                "name": "Radium node"
             },
             {
                 "url": "wss://people-polkadot.rotko.net",
@@ -1963,10 +1943,6 @@
             {
                 "url": "wss://shiden-rpc.n.dwellir.com",
                 "name": "Dwellir node"
-            },
-            {
-                "url": "wss://shiden.public.curie.radiumblock.co/ws",
-                "name": "RadiumBlock node"
             }
         ],
         "explorers": [
@@ -2341,7 +2317,7 @@
     {
         "chainId": "aa3876c1dc8a1afcc2e9a685a49ff7704cfd36ad8c90bf2702b9d1b00cc40011",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-        "name": "Altair",
+        "name": "Altair (PAUSED)",
         "assets": [
             {
                 "assetId": 0,
@@ -2749,10 +2725,6 @@
             {
                 "url": "wss://acala-rpc-3.aca-api.network/ws",
                 "name": "Acala Foundation 3 node"
-            },
-            {
-                "url": "wss://acala-rpc.n.dwellir.com",
-                "name": "Dwellir node"
             }
         ],
         "explorers": [
@@ -2962,8 +2934,8 @@
                 "name": "Dwellir node"
             },
             {
-                "url": "wss://astar.public.curie.radiumblock.co/ws",
-                "name": "RadiumBlock node"
+                "url": "wss://astar.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -5021,10 +4993,6 @@
                 "name": "Neckwork node"
             },
             {
-                "url": "wss://node-sparrow-1.sparrow.shadow-senate.com",
-                "name": "Sparrow node"
-            },
-            {
                 "url": "wss://hdx.tarn.hydration.cloud",
                 "name": "Tarn node"
             },
@@ -5578,10 +5546,6 @@
             {
                 "url": "wss://so.polkadex.ee",
                 "name": "PolkadexSup node"
-            },
-            {
-                "url": "wss://polkadex.public.curie.radiumblock.co/ws",
-                "name": "RadiumBlock node"
             }
         ],
         "externalApi": {
@@ -6987,7 +6951,7 @@
     {
         "chainId": "e358eb1d11b31255a286c12e44fe6780b7edb171d657905a97e39f71d9c6c3ee",
         "parentId": "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
-        "name": "Ajuna",
+        "name": "Ajuna (PAUSED)",
         "assets": [
             {
                 "assetId": 0,
@@ -7038,10 +7002,6 @@
             {
                 "url": "wss://rpc.3dpass.org",
                 "name": "3DPass node"
-            },
-            {
-                "url": "wss://rpc.p3d.top",
-                "name": "Lzmz node"
             }
         ],
         "explorers": [
@@ -7277,10 +7237,6 @@
         ],
         "nodes": [
             {
-                "url": "wss://rpc-anchor-1-mainnet-az-ue1.giantprotocol.org:443",
-                "name": "Anchor node 1"
-            },
-            {
                 "url": "wss://rpc-anchor-2-mainnet-az-ue1.giantprotocol.org:443",
                 "name": "Anchor node 2"
             }
@@ -7414,10 +7370,6 @@
         ],
         "nodes": [
             {
-                "url": "wss://collectives.public.curie.radiumblock.co/ws",
-                "name": "Radium node"
-            },
-            {
                 "url": "wss://dot-rpc.stakeworld.io/collectives",
                 "name": "Stakeworld node"
             },
@@ -7524,7 +7476,7 @@
     },
     {
         "chainId": "6b5e488e0fa8f9821110d5c13f4c468abcd43ce5e297e62b34c53c3346465956",
-        "name": "Joystream",
+        "name": "Joystream (PAUSED)",
         "assets": [
             {
                 "assetId": 0,
@@ -7804,10 +7756,6 @@
             {
                 "url": "https://pacific-rpc.manta.network/http",
                 "name": "Manta rpc 1 node"
-            },
-            {
-                "url": "https://1rpc.io/manta",
-                "name": "Manta rpc 2 node"
             },
             {
                 "url": "wss://pacific-rpc.manta.network/ws",

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -33,14 +33,6 @@
                 "name": "Stakeworld node"
             },
             {
-                "url": "wss://polkadot.public.curie.radiumblock.co/ws",
-                "name": "Radium node"
-            },
-            {
-                "url": "wss://1rpc.io/dot",
-                "name": "Automata 1RPC node"
-            },
-            {
                 "url": "wss://rpc-polkadot.luckyfriday.io",
                 "name": "LuckyFriday node"
             }
@@ -159,14 +151,6 @@
             {
                 "url": "wss://rpc-kusama.luckyfriday.io",
                 "name": "LuckyFriday node"
-            },
-            {
-                "url": "wss://1rpc.io/ksm",
-                "name": "Automata 1RPC node"
-            },
-            {
-                "url": "wss://kusama.public.curie.radiumblock.co/ws",
-                "name": "Radium node"
             }
         ],
         "explorers": [
@@ -1586,10 +1570,6 @@
             {
                 "url": "wss://shiden-rpc.n.dwellir.com",
                 "name": "Dwellir node"
-            },
-            {
-                "url": "wss://shiden.public.curie.radiumblock.co/ws",
-                "name": "RadiumBlock node"
             }
         ],
         "explorers": [
@@ -2219,7 +2199,7 @@
     {
         "chainId": "aa3876c1dc8a1afcc2e9a685a49ff7704cfd36ad8c90bf2702b9d1b00cc40011",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-        "name": "Altair",
+        "name": "Altair (PAUSED)",
         "assets": [
             {
                 "assetId": 0,
@@ -2632,10 +2612,6 @@
             {
                 "url": "wss://acala-rpc-3.aca-api.network/ws",
                 "name": "Acala Foundation 3 node"
-            },
-            {
-                "url": "wss://acala-rpc.n.dwellir.com",
-                "name": "Dwellir node"
             }
         ],
         "explorers": [
@@ -3409,8 +3385,8 @@
                 "name": "Astar node"
             },
             {
-                "url": "wss://astar.public.curie.radiumblock.co/ws",
-                "name": "RadiumBlock node"
+                "url": "wss://astar.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "explorers": [
@@ -5331,10 +5307,6 @@
                 "name": "Neckwork node"
             },
             {
-                "url": "wss://node-sparrow-1.sparrow.shadow-senate.com",
-                "name": "Sparrow node"
-            },
-            {
                 "url": "wss://hdx.tarn.hydration.cloud",
                 "name": "Tarn node"
             },
@@ -6015,10 +5987,6 @@
             {
                 "url": "wss://so.polkadex.ee",
                 "name": "PolkadexSup node"
-            },
-            {
-                "url": "wss://polkadex.public.curie.radiumblock.co/ws",
-                "name": "RadiumBlock node"
             }
         ],
         "externalApi": {
@@ -8085,10 +8053,6 @@
             {
                 "url": "wss://rpc.3dpass.org",
                 "name": "3DPass node"
-            },
-            {
-                "url": "wss://rpc.p3d.top",
-                "name": "Lzmz node"
             }
         ],
         "explorers": [
@@ -8112,7 +8076,7 @@
     {
         "chainId": "e358eb1d11b31255a286c12e44fe6780b7edb171d657905a97e39f71d9c6c3ee",
         "parentId": "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
-        "name": "Ajuna",
+        "name": "Ajuna (PAUSED)",
         "assets": [
             {
                 "assetId": 0,
@@ -8375,10 +8339,6 @@
             }
         ],
         "nodes": [
-            {
-                "url": "wss://rpc-anchor-1-mainnet-az-ue1.giantprotocol.org:443",
-                "name": "Anchor node 1"
-            },
             {
                 "url": "wss://rpc-anchor-2-mainnet-az-ue1.giantprotocol.org:443",
                 "name": "Anchor node 2"
@@ -8699,10 +8659,6 @@
         ],
         "nodes": [
             {
-                "url": "wss://collectives.public.curie.radiumblock.co/ws",
-                "name": "Radium node"
-            },
-            {
                 "url": "wss://dot-rpc.stakeworld.io/collectives",
                 "name": "Stakeworld node"
             },
@@ -8763,10 +8719,6 @@
             {
                 "url": "wss://rpc-people-polkadot.luckyfriday.io",
                 "name": "LuckyFriday node"
-            },
-            {
-                "url": "wss://people-polkadot.public.curie.radiumblock.co/ws",
-                "name": "Radium node"
             },
             {
                 "url": "wss://people-polkadot.rotko.net",
@@ -9448,7 +9400,7 @@
     },
     {
         "chainId": "6b5e488e0fa8f9821110d5c13f4c468abcd43ce5e297e62b34c53c3346465956",
-        "name": "Joystream",
+        "name": "Joystream (PAUSED)",
         "assets": [
             {
                 "assetId": 0,
@@ -9681,10 +9633,6 @@
             {
                 "url": "https://pacific-rpc.manta.network/http",
                 "name": "Manta rpc 1 node"
-            },
-            {
-                "url": "https://1rpc.io/manta",
-                "name": "Manta rpc 2 node"
             },
             {
                 "url": "wss://pacific-rpc.manta.network/ws",


### PR DESCRIPTION
Follow-up to #4369, which paused 17 networks that had stopped producing blocks.
This covers the three that sweep missed, and cleans up RPC endpoints that no
longer respond.

### Paused (3)

Every network in the wallet was probed against its configured RPC endpoints, then
each failure was manually confirmed before being included here.

| Network | Evidence |
|---|---|
| **Altair** | Last block ~3,810 hours ago (~159 days). Its only endpoint (`altair.api.onfinality.io/public-ws`) now returns `-32029 Too Many Requests, please apply an API key`. |
| **Ajuna** | Only endpoint `rpc-para.ajuna.network` resolves but refuses connections. |
| **Joystream** | Only endpoint `rpc.joystream.org` no longer resolves (NXDOMAIN). |

### RPC endpoints removed (14 across 12 networks)

Mostly RadiumBlock (`*.public.curie.radiumblock.co`) and `1rpc.io`, which have
either stopped responding or now rate-limit to the point of being unusable:

- **Polkadot Relay** — `1rpc.io/dot`, `polkadot.public.curie.radiumblock.co/ws`
- **Kusama Relay** — `1rpc.io/ksm`, `kusama.public.curie.radiumblock.co/ws`
- **Polkadot Collectives** — `collectives.public.curie.radiumblock.co/ws`
- **Polkadot People** — `people-polkadot.public.curie.radiumblock.co/ws`
- **Astar** — `astar.public.curie.radiumblock.co/ws`
- **Shiden** — `shiden.public.curie.radiumblock.co/ws`
- **Polkadex** — `polkadex.public.curie.radiumblock.co/ws`
- **Acala** — `acala-rpc.n.dwellir.com`
- **Manta Pacific** — `1rpc.io/manta`
- **Hydration** — `node-sparrow-1.sparrow.shadow-senate.com`
- **GIANT** — `rpc-anchor-1-mainnet-az-ue1.giantprotocol.org:443`
- **3DPass (PAUSED)** — `rpc.p3d.top`

Every affected network keeps at least one working endpoint; the change was
validated to ensure no network is left with an empty node list. Acala retains its
four `aca-api.network` endpoints.

### RPC endpoint added (1)

- **Astar** — `wss://astar.api.onfinality.io/public-ws` (verified responding)

### Notes

Endpoint failures were confirmed by hand rather than taken from the automated
probe alone — the probe produced at least one false negative (a Bifrost Polkadot
endpoint it reported unreachable is in fact fine), so only manually verified
failures are removed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
