### PR TITLE
dev: add HOLLAR on Polkadot Asset Hub with Hydration <> Asset Hub transfers

### DIFF
--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -3763,6 +3763,19 @@
                 "typeExtras": {
                     "assetId": "50000111"
                 }
+            },
+            {
+                "assetId": 28,
+                "symbol": "HOLLAR",
+                "precision": 18,
+                "priceId": "hydrated-dollar",
+                "type": "statemine",
+                "icon": "HOLLAR.svg",
+                "typeExtras": {
+                    "assetId": "0x010200c91f057903",
+                    "palletName": "ForeignAssets",
+                    "isSufficient": true
+                }
             }
         ],
         "nodes": [
@@ -5196,7 +5209,7 @@
                 "assetId": 65,
                 "symbol": "HOLLAR",
                 "precision": 18,
-                "priceId": "tether",
+                "priceId": "hydrated-dollar",
                 "type": "orml-hydration-evm",
                 "icon": "HOLLAR.svg",
                 "typeExtras": {

--- a/xcm/v8/transfers_dev.json
+++ b/xcm/v8/transfers_dev.json
@@ -459,6 +459,20 @@
         },
         "instructions": "xtokensReserve"
       }
+    },
+    "HOLLAR": {
+      "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+      "multiLocation": {
+        "parachainId": 2034,
+        "generalIndex": "222"
+      },
+      "reserveFee": {
+        "mode": {
+          "type": "proportional",
+          "value": "2000000000000000000"
+        },
+        "instructions": "xtokensReserve"
+      }
     }
   },
   "instructions": {
@@ -2836,6 +2850,29 @@
               "type": "xcmpallet"
             }
           ]
+        },
+        {
+          "assetId": 28,
+          "assetLocation": "HOLLAR",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+                "assetId": 65,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "3000000000000000000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
+            }
+          ]
         }
       ]
     },
@@ -3645,6 +3682,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "70000000000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 65,
+          "assetLocation": "HOLLAR",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+                "assetId": 28,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "2000000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
### HOLLAR on Polkadot Asset Hub (`chains_dev.json`)

HOLLAR (Hydration's stablecoin) has been live on Polkadot Asset Hub since June as a
`ForeignAssets` asset — ~700k supply across 40 holders, created via XCM from Hydration.

- Location `parents: 1, X2(Parachain(2034), GeneralIndex(222))` → `0x010200c91f057903`,
  18 decimals, `isSufficient: true`, ED 0.02 HOLLAR — all verified on-chain
- `priceId: hydrated-dollar` (CoinGecko lists it properly now; its platform contract
  matches Hydration's registry)
- Also fixes the existing Hydration HOLLAR entry, which still had the `tether`
  placeholder priceId from Sept 2025
- Icon already in the repo
- assetId 28 (25 is a historical gap and stays unused)

### XCM transfers (`transfers_dev.json`)

Hydration → Asset Hub (`xtokens`) and Asset Hub → Hydration (`xcmpallet`), both in the
**legacy** config, mirroring how MYTH is configured in both directions.

Legacy rather than dynamic is deliberate: HOLLAR is `orml-hydration-evm`, i.e.
ERC-20-backed on Hydration, and the dry-run pipeline cannot fund such assets in
simulation — `Currencies.update_balance` returns `NotSupported` for Erc20-type
currencies and `Tokens.set_balance` writes storage the Erc20 adapter doesn't read.
Verified against the live runtime.

Both directions were validated with `DryRunApi` against live chains (impersonating an
existing HOLLAR holder as origin):

- Hydration → PAH: `transfer_multiasset` withdraws via the ERC-20 path and emits the
  expected `ReserveAssetDeposited / ClearOrigin / BuyExecution / DepositAsset` message;
  PAH accepts HOLLAR as a fee asset (XCM v3/v4/v5)
- PAH → Hydration: reserve-withdraw executes and Hydration deposits `currency_id: 222`
  to the beneficiary
- Real-world precedent: 53.8k HOLLAR moved Hydration → AH at block 12711112

Fee coefficients are derived from live `XcmPaymentApi` quotes plus ~2× headroom
(measured destination costs: 0.0037 HOLLAR on PAH, 0.00067 on Hydration); surplus is
returned to the beneficiary by `DepositAsset`. Feel free to fix up the fee values if
you'd prefer different margins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
