### PR TITLE
Remove priceId from assets whose price history is empty (crash NW-2133)

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -713,7 +713,6 @@
                 "assetId": 7,
                 "symbol": "KINT",
                 "precision": 12,
-                "priceId": "kintsugi",
                 "type": "orml",
                 "icon": "KINT.svg",
                 "typeExtras": {
@@ -780,7 +779,6 @@
                 "assetId": 12,
                 "symbol": "QTZ",
                 "precision": 18,
-                "priceId": "quartz",
                 "type": "orml",
                 "icon": "QTZ.svg",
                 "typeExtras": {
@@ -821,7 +819,6 @@
                 "assetId": 16,
                 "symbol": "CSM",
                 "precision": 12,
-                "priceId": "crust-storage-market",
                 "type": "orml",
                 "icon": "CSM.svg",
                 "typeExtras": {
@@ -849,7 +846,6 @@
                 "assetId": 18,
                 "symbol": "KMA",
                 "precision": 12,
-                "priceId": "calamari-network",
                 "type": "orml",
                 "icon": "KMA.svg",
                 "typeExtras": {
@@ -863,7 +859,6 @@
                 "assetId": 19,
                 "symbol": "TEER",
                 "precision": 12,
-                "priceId": "integritee",
                 "type": "orml",
                 "icon": "TEER.svg",
                 "typeExtras": {
@@ -890,7 +885,6 @@
                 "assetId": 21,
                 "symbol": "NEER",
                 "precision": 18,
-                "priceId": "metaverse-network-pioneer",
                 "type": "orml",
                 "icon": "NEER.svg",
                 "typeExtras": {
@@ -904,7 +898,6 @@
                 "assetId": 22,
                 "symbol": "BSX",
                 "precision": 12,
-                "priceId": "basilisk",
                 "type": "orml",
                 "icon": "BSX.svg",
                 "typeExtras": {
@@ -918,7 +911,6 @@
                 "assetId": 23,
                 "symbol": "AIR",
                 "precision": 18,
-                "priceId": "altair",
                 "type": "orml",
                 "icon": "AIR.svg",
                 "typeExtras": {
@@ -933,7 +925,6 @@
                 "symbol": "GENS",
                 "precision": 9,
                 "type": "orml",
-                "priceId": "genshiro",
                 "icon": "GENS.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x050e00",
@@ -961,7 +952,6 @@
                 "symbol": "CRAB",
                 "precision": 18,
                 "type": "orml",
-                "priceId": "darwinia-crab-network",
                 "icon": "CRAB.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x050d00",
@@ -1060,7 +1050,6 @@
                 "symbol": "xcaSEEDp",
                 "precision": 12,
                 "type": "statemine",
-                "priceId": "ausd-seed-acala",
                 "icon": "aSEEDp.svg",
                 "typeExtras": {
                     "assetId": "110021739665376159354538090254163045594",
@@ -1093,7 +1082,6 @@
                 "symbol": "xcINTR",
                 "precision": 10,
                 "type": "evm",
-                "priceId": "interlay",
                 "icon": "INTR.svg",
                 "typeExtras": {
                     "contractAddress": "0xFffFFFFF4C1cbCd97597339702436d4F18a375Ab"
@@ -1170,7 +1158,6 @@
                 "symbol": "xcEQ",
                 "precision": 9,
                 "type": "evm",
-                "priceId": "equilibrium-token",
                 "icon": "EQ.svg",
                 "typeExtras": {
                     "contractAddress": "0xFffFFfFf8f6267e040D8a0638C576dfBa4F0F6D6"
@@ -1256,7 +1243,6 @@
                 "assetId": 21,
                 "symbol": "xcvGLMR",
                 "precision": 18,
-                "priceId": "voucher-glmr",
                 "type": "evm",
                 "icon": "vGLMR.svg",
                 "typeExtras": {
@@ -1505,7 +1491,6 @@
                 "assetId": 3,
                 "symbol": "xcKINT",
                 "precision": 12,
-                "priceId": "kintsugi",
                 "type": "evm",
                 "icon": "KINT.svg",
                 "typeExtras": {
@@ -1572,7 +1557,6 @@
                 "assetId": 9,
                 "symbol": "xcCSM",
                 "precision": 12,
-                "priceId": "crust-storage-market",
                 "type": "evm",
                 "icon": "CSM.svg",
                 "typeExtras": {
@@ -1604,7 +1588,6 @@
                 "assetId": 12,
                 "symbol": "xcKMA",
                 "precision": 12,
-                "priceId": "calamari-network",
                 "type": "evm",
                 "icon": "KMA.svg",
                 "typeExtras": {
@@ -1615,7 +1598,6 @@
                 "assetId": 13,
                 "symbol": "xcCRAB",
                 "precision": 18,
-                "priceId": "darwinia-crab-network",
                 "type": "evm",
                 "icon": "CRAB.svg",
                 "typeExtras": {
@@ -1626,7 +1608,6 @@
                 "assetId": 14,
                 "symbol": "xcTEER",
                 "precision": 12,
-                "priceId": "integritee",
                 "type": "evm",
                 "icon": "TEER.svg",
                 "typeExtras": {
@@ -1648,7 +1629,6 @@
                 "assetId": 16,
                 "symbol": "xcSDN",
                 "precision": 18,
-                "priceId": "shiden",
                 "type": "evm",
                 "icon": "SDN.svg",
                 "typeExtras": {
@@ -1702,7 +1682,6 @@
                 "symbol": "xcMGX",
                 "precision": 18,
                 "type": "evm",
-                "priceId": "mangata-x",
                 "icon": "MGX.svg",
                 "typeExtras": {
                     "contractAddress": "0xffFfFffF58d867EEa1Ce5126A4769542116324e9"
@@ -1713,7 +1692,6 @@
                 "symbol": "xcTUR",
                 "precision": 10,
                 "type": "evm",
-                "priceId": "turing-network",
                 "icon": "TUR.svg",
                 "typeExtras": {
                     "contractAddress": "0xfFffffFf6448d0746f2a66342B67ef9CAf89478E"
@@ -1807,8 +1785,7 @@
                 "assetId": 0,
                 "symbol": "SDN",
                 "precision": 18,
-                "icon": "SDN.svg",
-                "priceId": "shiden"
+                "icon": "SDN.svg"
             },
             {
                 "assetId": 1,
@@ -1863,7 +1840,6 @@
                 "symbol": "KINT",
                 "precision": 12,
                 "type": "statemine",
-                "priceId": "kintsugi",
                 "icon": "KINT.svg",
                 "typeExtras": {
                     "assetId": "18446744073709551622",
@@ -1899,7 +1875,6 @@
                 "symbol": "CSM",
                 "precision": 12,
                 "type": "statemine",
-                "priceId": "crust-storage-market",
                 "icon": "CSM.svg",
                 "typeExtras": {
                     "assetId": "18446744073709551624",
@@ -2032,7 +2007,6 @@
                 "assetId": 3,
                 "symbol": "ZLK",
                 "precision": 18,
-                "priceId": "zenlink-network-token",
                 "type": "orml",
                 "icon": "ZLK.svg",
                 "typeExtras": {
@@ -2224,7 +2198,6 @@
                 "assetId": 0,
                 "symbol": "BSX",
                 "precision": 12,
-                "priceId": "basilisk",
                 "icon": "BSX.svg",
                 "buyProviders": {
                     "banxa": {
@@ -2347,8 +2320,7 @@
                 "assetId": 0,
                 "symbol": "AIR",
                 "precision": 18,
-                "icon": "AIR.svg",
-                "priceId": "altair"
+                "icon": "AIR.svg"
             }
         ],
         "nodes": [
@@ -2387,7 +2359,6 @@
                 "assetId": 0,
                 "symbol": "EDG",
                 "precision": 18,
-                "priceId": "edgeware",
                 "icon": "EDG.svg"
             }
         ],
@@ -2416,7 +2387,6 @@
             {
                 "assetId": 0,
                 "symbol": "KILT",
-                "priceId": "kilt-protocol",
                 "icon": "KILT.svg",
                 "precision": 15,
                 "buyProviders": {
@@ -2470,7 +2440,6 @@
             {
                 "assetId": 0,
                 "symbol": "QTZ",
-                "priceId": "quartz",
                 "icon": "QTZ.svg",
                 "precision": 18
             }
@@ -2517,7 +2486,6 @@
                 "assetId": 1,
                 "symbol": "LDOT",
                 "precision": 10,
-                "priceId": "liquid-staking-dot",
                 "type": "orml",
                 "icon": "LDOT.svg",
                 "typeExtras": {
@@ -2531,7 +2499,6 @@
                 "assetId": 2,
                 "symbol": "aSEEDp",
                 "precision": 12,
-                "priceId": "ausd-seed-acala",
                 "type": "orml",
                 "icon": "aSEEDp.svg",
                 "typeExtras": {
@@ -2627,7 +2594,6 @@
                 "symbol": "INTR",
                 "precision": 10,
                 "type": "orml",
-                "priceId": "interlay",
                 "icon": "INTR.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x050400",
@@ -2654,7 +2620,6 @@
                 "assetId": 11,
                 "symbol": "EQ",
                 "precision": 9,
-                "priceId": "equilibrium-token",
                 "type": "orml",
                 "icon": "EQ.svg",
                 "typeExtras": {
@@ -2836,7 +2801,6 @@
                 "symbol": "INTR",
                 "precision": 10,
                 "type": "statemine",
-                "priceId": "interlay",
                 "icon": "INTR.svg",
                 "typeExtras": {
                     "assetId": "18446744073709551621",
@@ -2872,7 +2836,6 @@
                 "symbol": "LDOT",
                 "precision": 10,
                 "type": "statemine",
-                "priceId": "liquid-staking-dot",
                 "icon": "LDOT.svg",
                 "typeExtras": {
                     "assetId": "18446744073709551618",
@@ -2884,7 +2847,6 @@
                 "symbol": "aSEEDp",
                 "precision": 12,
                 "type": "statemine",
-                "priceId": "ausd-seed-acala",
                 "icon": "aSEEDp.svg",
                 "typeExtras": {
                     "assetId": "18446744073709551617",
@@ -3042,7 +3004,6 @@
                 "assetId": 3,
                 "symbol": "DED",
                 "precision": 10,
-                "priceId": "dot-is-ded",
                 "type": "statemine",
                 "icon": "DED.svg",
                 "typeExtras": {
@@ -3283,7 +3244,6 @@
                 "assetId": 26,
                 "symbol": "MPC",
                 "precision": 12,
-                "priceId": "my-paqman-coin",
                 "icon": "MPC.png",
                 "type": "statemine",
                 "typeExtras": {
@@ -3294,7 +3254,6 @@
                 "assetId": 27,
                 "symbol": "DON",
                 "precision": 12,
-                "priceId": "paydon",
                 "icon": "DON.png",
                 "type": "statemine",
                 "typeExtras": {
@@ -3502,7 +3461,6 @@
                 "symbol": "KINT",
                 "precision": 12,
                 "type": "orml",
-                "priceId": "kintsugi",
                 "icon": "KINT.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x000c",
@@ -3699,7 +3657,6 @@
                 "assetId": 0,
                 "symbol": "PICA",
                 "precision": 12,
-                "priceId": "picasso",
                 "icon": "PICA.svg"
             },
             {
@@ -3773,7 +3730,6 @@
                     "parachain"
                 ],
                 "precision": 10,
-                "priceId": "zeitgeist",
                 "icon": "ZTG.svg"
             }
         ],
@@ -3826,7 +3782,6 @@
                 "assetId": 0,
                 "symbol": "SUB",
                 "precision": 10,
-                "priceId": "subsocial",
                 "icon": "SUB.svg"
             }
         ],
@@ -3860,7 +3815,6 @@
                 "assetId": 0,
                 "symbol": "CSM",
                 "precision": 12,
-                "priceId": "crust-storage-market",
                 "icon": "CSM.svg"
             }
         ],
@@ -3909,7 +3863,6 @@
                 "assetId": 0,
                 "symbol": "TEER",
                 "precision": 12,
-                "priceId": "integritee",
                 "icon": "TEER.svg"
             }
         ],
@@ -4093,7 +4046,6 @@
                 "assetId": 7,
                 "symbol": "ZTG",
                 "precision": 10,
-                "priceId": "zeitgeist",
                 "type": "orml",
                 "icon": "ZTG.svg",
                 "typeExtras": {
@@ -4233,7 +4185,6 @@
                 "assetId": 17,
                 "symbol": "INTR",
                 "precision": 10,
-                "priceId": "interlay",
                 "icon": "INTR.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -4247,7 +4198,6 @@
                 "assetId": 18,
                 "symbol": "SUB",
                 "precision": 10,
-                "priceId": "subsocial",
                 "icon": "SUB.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -4398,7 +4348,6 @@
                 "assetId": 29,
                 "symbol": "DED",
                 "precision": 10,
-                "priceId": "dot-is-ded",
                 "type": "orml",
                 "icon": "DED.svg",
                 "typeExtras": {
@@ -4465,7 +4414,6 @@
                 "symbol": "KILT",
                 "precision": 15,
                 "type": "orml",
-                "priceId": "kilt-protocol",
                 "icon": "KILT.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x1c000000",
@@ -5079,7 +5027,6 @@
                 "assetId": 0,
                 "symbol": "INTR",
                 "precision": 10,
-                "priceId": "interlay",
                 "icon": "INTR.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -5127,7 +5074,6 @@
                 "assetId": 3,
                 "symbol": "KINT",
                 "precision": 12,
-                "priceId": "kintsugi",
                 "icon": "KINT.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -5169,7 +5115,6 @@
                 "assetId": 6,
                 "symbol": "LDOT",
                 "precision": 10,
-                "priceId": "liquid-staking-dot",
                 "icon": "LDOT.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -5471,7 +5416,6 @@
             {
                 "assetId": 0,
                 "symbol": "PDEX",
-                "priceId": "polkadex",
                 "staking": [
                     "relaychain"
                 ],
@@ -5542,7 +5486,6 @@
                 "assetId": 6,
                 "symbol": "DED",
                 "precision": 12,
-                "priceId": "dot-is-ded",
                 "type": "statemine",
                 "icon": "DED.svg",
                 "typeExtras": {
@@ -5748,7 +5691,6 @@
                 "assetId": 6,
                 "symbol": "vGLMR",
                 "precision": 18,
-                "priceId": "voucher-glmr",
                 "type": "orml",
                 "icon": "vGLMR.svg",
                 "typeExtras": {
@@ -5981,7 +5923,6 @@
             {
                 "assetId": 0,
                 "symbol": "MGX",
-                "priceId": "mangata-x",
                 "precision": 18,
                 "icon": "MGX.svg",
                 "type": "orml",
@@ -6024,7 +5965,6 @@
                 "assetId": 3,
                 "symbol": "TUR",
                 "precision": 10,
-                "priceId": "turing-network",
                 "icon": "TUR.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -6066,7 +6006,6 @@
                 "assetId": 6,
                 "symbol": "ZLK",
                 "precision": 18,
-                "priceId": "zenlink-network-token",
                 "icon": "ZLK.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -6442,7 +6381,6 @@
                 "assetId": 0,
                 "symbol": "MYRIA",
                 "precision": 18,
-                "priceId": "myriad-social",
                 "icon": "MYRIA.svg"
             }
         ],
@@ -6900,7 +6838,6 @@
             {
                 "assetId": 0,
                 "symbol": "SAMA",
-                "priceId": "exosama-network",
                 "type": "evmNative",
                 "icon": "SAMA.svg",
                 "precision": 18
@@ -7030,7 +6967,6 @@
                 "assetId": 0,
                 "symbol": "P3D",
                 "precision": 12,
-                "priceId": "3dpass",
                 "icon": "P3D.svg"
             }
         ],
@@ -7463,7 +7399,6 @@
                 "assetId": 0,
                 "symbol": "KREST",
                 "precision": 18,
-                "priceId": "krest",
                 "icon": "KREST.svg"
             }
         ],
@@ -7529,7 +7464,6 @@
             {
                 "assetId": 0,
                 "symbol": "JOY",
-                "priceId": "joystream",
                 "precision": 10,
                 "icon": "JOY.svg"
             }
@@ -7565,7 +7499,6 @@
             {
                 "assetId": 0,
                 "symbol": "DOCK",
-                "priceId": "dock",
                 "precision": 6,
                 "icon": "DOCK.svg"
             }
@@ -7892,7 +7825,6 @@
                 "assetId": 0,
                 "symbol": "CGT",
                 "precision": 18,
-                "priceId": "curio-governance",
                 "icon": "CGT.svg"
             }
         ],
@@ -8060,7 +7992,6 @@
                 "assetId": 0,
                 "symbol": "BRIDGE",
                 "precision": 12,
-                "priceId": "hyperbridge-2",
                 "icon": "BRIDGE.svg"
             }
         ],
@@ -8480,7 +8411,6 @@
                 "assetId": 0,
                 "symbol": "LAOS",
                 "precision": 18,
-                "priceId": "laos-network",
                 "icon": "LAOS.svg"
             }
         ],
@@ -8701,7 +8631,6 @@
                 "assetId": 0,
                 "symbol": "TNT",
                 "precision": 18,
-                "priceId": "tangle-network",
                 "icon": "TNT.svg"
             }
         ],
@@ -8836,7 +8765,6 @@
                 "assetId": 0,
                 "symbol": "AGC",
                 "precision": 18,
-                "priceId": "argocoin-2",
                 "icon": "AGC.svg"
             }
         ],
@@ -8864,7 +8792,6 @@
                 "assetId": 0,
                 "symbol": "TANSSI",
                 "precision": 12,
-                "priceId": "tanssi",
                 "icon": "TANSSI.svg"
             }
         ],

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -719,7 +719,6 @@
                 "assetId": 7,
                 "symbol": "KINT",
                 "precision": 12,
-                "priceId": "kintsugi",
                 "type": "orml",
                 "icon": "KINT.svg",
                 "typeExtras": {
@@ -786,7 +785,6 @@
                 "assetId": 12,
                 "symbol": "QTZ",
                 "precision": 18,
-                "priceId": "quartz",
                 "type": "orml",
                 "icon": "QTZ.svg",
                 "typeExtras": {
@@ -827,7 +825,6 @@
                 "assetId": 16,
                 "symbol": "CSM",
                 "precision": 12,
-                "priceId": "crust-storage-market",
                 "type": "orml",
                 "icon": "CSM.svg",
                 "typeExtras": {
@@ -855,7 +852,6 @@
                 "assetId": 18,
                 "symbol": "KMA",
                 "precision": 12,
-                "priceId": "calamari-network",
                 "type": "orml",
                 "icon": "KMA.svg",
                 "typeExtras": {
@@ -869,7 +865,6 @@
                 "assetId": 19,
                 "symbol": "TEER",
                 "precision": 12,
-                "priceId": "integritee",
                 "type": "orml",
                 "icon": "TEER.svg",
                 "typeExtras": {
@@ -896,7 +891,6 @@
                 "assetId": 21,
                 "symbol": "NEER",
                 "precision": 18,
-                "priceId": "metaverse-network-pioneer",
                 "type": "orml",
                 "icon": "NEER.svg",
                 "typeExtras": {
@@ -910,7 +904,6 @@
                 "assetId": 22,
                 "symbol": "BSX",
                 "precision": 12,
-                "priceId": "basilisk",
                 "type": "orml",
                 "icon": "BSX.svg",
                 "typeExtras": {
@@ -924,7 +917,6 @@
                 "assetId": 23,
                 "symbol": "AIR",
                 "precision": 18,
-                "priceId": "altair",
                 "type": "orml",
                 "icon": "AIR.svg",
                 "typeExtras": {
@@ -939,7 +931,6 @@
                 "symbol": "GENS",
                 "precision": 9,
                 "type": "orml",
-                "priceId": "genshiro",
                 "icon": "GENS.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x050e00",
@@ -967,7 +958,6 @@
                 "symbol": "CRAB",
                 "precision": 18,
                 "type": "orml",
-                "priceId": "darwinia-crab-network",
                 "icon": "CRAB.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x050d00",
@@ -1068,7 +1058,6 @@
                 "assetId": 3,
                 "symbol": "xcKINT",
                 "precision": 12,
-                "priceId": "kintsugi",
                 "type": "evm",
                 "icon": "KINT.svg",
                 "typeExtras": {
@@ -1135,7 +1124,6 @@
                 "assetId": 9,
                 "symbol": "xcCSM",
                 "precision": 12,
-                "priceId": "crust-storage-market",
                 "type": "evm",
                 "icon": "CSM.svg",
                 "typeExtras": {
@@ -1167,7 +1155,6 @@
                 "assetId": 12,
                 "symbol": "xcKMA",
                 "precision": 12,
-                "priceId": "calamari-network",
                 "type": "evm",
                 "icon": "KMA.svg",
                 "typeExtras": {
@@ -1178,7 +1165,6 @@
                 "assetId": 13,
                 "symbol": "xcCRAB",
                 "precision": 18,
-                "priceId": "darwinia-crab-network",
                 "type": "evm",
                 "icon": "CRAB.svg",
                 "typeExtras": {
@@ -1189,7 +1175,6 @@
                 "assetId": 14,
                 "symbol": "xcTEER",
                 "precision": 12,
-                "priceId": "integritee",
                 "type": "evm",
                 "icon": "TEER.svg",
                 "typeExtras": {
@@ -1211,7 +1196,6 @@
                 "assetId": 16,
                 "symbol": "xcSDN",
                 "precision": 18,
-                "priceId": "shiden",
                 "type": "evm",
                 "icon": "SDN.svg",
                 "typeExtras": {
@@ -1265,7 +1249,6 @@
                 "symbol": "xcMGX",
                 "precision": 18,
                 "type": "evm",
-                "priceId": "mangata-x",
                 "icon": "MGX.svg",
                 "typeExtras": {
                     "contractAddress": "0xffFfFffF58d867EEa1Ce5126A4769542116324e9"
@@ -1276,7 +1259,6 @@
                 "symbol": "xcTUR",
                 "precision": 10,
                 "type": "evm",
-                "priceId": "turing-network",
                 "icon": "TUR.svg",
                 "typeExtras": {
                     "contractAddress": "0xfFffffFf6448d0746f2a66342B67ef9CAf89478E"
@@ -1430,8 +1412,7 @@
                 "assetId": 0,
                 "symbol": "SDN",
                 "precision": 18,
-                "icon": "SDN.svg",
-                "priceId": "shiden"
+                "icon": "SDN.svg"
             },
             {
                 "assetId": 1,
@@ -1486,7 +1467,6 @@
                 "symbol": "KINT",
                 "precision": 12,
                 "type": "statemine",
-                "priceId": "kintsugi",
                 "icon": "KINT.svg",
                 "typeExtras": {
                     "assetId": "18446744073709551622",
@@ -1522,7 +1502,6 @@
                 "symbol": "CSM",
                 "precision": 12,
                 "type": "statemine",
-                "priceId": "crust-storage-market",
                 "icon": "CSM.svg",
                 "typeExtras": {
                     "assetId": "18446744073709551624",
@@ -1670,7 +1649,6 @@
                 "assetId": 3,
                 "symbol": "ZLK",
                 "precision": 18,
-                "priceId": "zenlink-network-token",
                 "type": "orml",
                 "icon": "ZLK.svg",
                 "typeExtras": {
@@ -1866,7 +1844,6 @@
                 "symbol": "KINT",
                 "precision": 12,
                 "type": "orml",
-                "priceId": "kintsugi",
                 "icon": "KINT.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x000c",
@@ -2065,7 +2042,6 @@
                 "assetId": 0,
                 "symbol": "EDG",
                 "precision": 18,
-                "priceId": "edgeware",
                 "icon": "EDG.svg",
                 "staking": [
                     "aura-relaychain"
@@ -2102,7 +2078,6 @@
                 "assetId": 0,
                 "symbol": "BSX",
                 "precision": 12,
-                "priceId": "basilisk",
                 "icon": "BSX.svg",
                 "buyProviders": {
                     "banxa": {
@@ -2225,8 +2200,7 @@
                 "assetId": 0,
                 "symbol": "AIR",
                 "precision": 18,
-                "icon": "AIR.svg",
-                "priceId": "altair"
+                "icon": "AIR.svg"
             }
         ],
         "nodes": [
@@ -2265,7 +2239,6 @@
             {
                 "assetId": 0,
                 "symbol": "KILT",
-                "priceId": "kilt-protocol",
                 "icon": "KILT.svg",
                 "precision": 15,
                 "buyProviders": {
@@ -2352,7 +2325,6 @@
             {
                 "assetId": 0,
                 "symbol": "QTZ",
-                "priceId": "quartz",
                 "icon": "QTZ.svg",
                 "precision": 18
             }
@@ -2400,7 +2372,6 @@
                 "assetId": 1,
                 "symbol": "LDOT",
                 "precision": 10,
-                "priceId": "liquid-staking-dot",
                 "type": "orml",
                 "icon": "LDOT.svg",
                 "typeExtras": {
@@ -2414,7 +2385,6 @@
                 "assetId": 2,
                 "symbol": "aSEEDp",
                 "precision": 12,
-                "priceId": "ausd-seed-acala",
                 "type": "orml",
                 "icon": "aSEEDp.svg",
                 "typeExtras": {
@@ -2510,7 +2480,6 @@
                 "symbol": "INTR",
                 "precision": 10,
                 "type": "orml",
-                "priceId": "interlay",
                 "icon": "INTR.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x050400",
@@ -2537,7 +2506,6 @@
                 "assetId": 11,
                 "symbol": "EQ",
                 "precision": 9,
-                "priceId": "equilibrium-token",
                 "type": "orml",
                 "icon": "EQ.svg",
                 "typeExtras": {
@@ -2748,7 +2716,6 @@
                 "symbol": "xcaSEEDp",
                 "precision": 12,
                 "type": "statemine",
-                "priceId": "ausd-seed-acala",
                 "icon": "aSEEDp.svg",
                 "typeExtras": {
                     "assetId": "110021739665376159354538090254163045594",
@@ -2781,7 +2748,6 @@
                 "symbol": "xcINTR",
                 "precision": 10,
                 "type": "evm",
-                "priceId": "interlay",
                 "icon": "INTR.svg",
                 "typeExtras": {
                     "contractAddress": "0xFffFFFFF4C1cbCd97597339702436d4F18a375Ab"
@@ -2858,7 +2824,6 @@
                 "symbol": "xcEQ",
                 "precision": 9,
                 "type": "evm",
-                "priceId": "equilibrium-token",
                 "icon": "EQ.svg",
                 "typeExtras": {
                     "contractAddress": "0xFffFFfFf8f6267e040D8a0638C576dfBa4F0F6D6"
@@ -2944,7 +2909,6 @@
                 "assetId": 21,
                 "symbol": "xcvGLMR",
                 "precision": 18,
-                "priceId": "voucher-glmr",
                 "type": "evm",
                 "icon": "vGLMR.svg",
                 "typeExtras": {
@@ -3287,7 +3251,6 @@
                 "symbol": "INTR",
                 "precision": 10,
                 "type": "statemine",
-                "priceId": "interlay",
                 "icon": "INTR.svg",
                 "typeExtras": {
                     "assetId": "18446744073709551621",
@@ -3323,7 +3286,6 @@
                 "symbol": "LDOT",
                 "precision": 10,
                 "type": "statemine",
-                "priceId": "liquid-staking-dot",
                 "icon": "LDOT.svg",
                 "typeExtras": {
                     "assetId": "18446744073709551618",
@@ -3335,7 +3297,6 @@
                 "symbol": "aSEEDp",
                 "precision": 12,
                 "type": "statemine",
-                "priceId": "ausd-seed-acala",
                 "icon": "aSEEDp.svg",
                 "typeExtras": {
                     "assetId": "18446744073709551617",
@@ -3505,7 +3466,6 @@
                 "assetId": 3,
                 "symbol": "DED",
                 "precision": 10,
-                "priceId": "dot-is-ded",
                 "type": "statemine",
                 "icon": "DED.svg",
                 "typeExtras": {
@@ -3746,7 +3706,6 @@
                 "assetId": 26,
                 "symbol": "MPC",
                 "precision": 12,
-                "priceId": "my-paqman-coin",
                 "icon": "MPC.png",
                 "type": "statemine",
                 "typeExtras": {
@@ -3757,7 +3716,6 @@
                 "assetId": 27,
                 "symbol": "DON",
                 "precision": 12,
-                "priceId": "paydon",
                 "icon": "DON.png",
                 "type": "statemine",
                 "typeExtras": {
@@ -3977,7 +3935,6 @@
                 "assetId": 0,
                 "symbol": "PICA",
                 "precision": 12,
-                "priceId": "picasso",
                 "icon": "PICA.svg"
             },
             {
@@ -4054,7 +4011,6 @@
                     "parachain"
                 ],
                 "precision": 10,
-                "priceId": "zeitgeist",
                 "icon": "ZTG.svg"
             },
             {
@@ -4121,7 +4077,6 @@
                 "assetId": 0,
                 "symbol": "SUB",
                 "precision": 10,
-                "priceId": "subsocial",
                 "icon": "SUB.svg"
             }
         ],
@@ -4155,7 +4110,6 @@
                 "assetId": 0,
                 "symbol": "CSM",
                 "precision": 12,
-                "priceId": "crust-storage-market",
                 "icon": "CSM.svg"
             }
         ],
@@ -4216,7 +4170,6 @@
                 "assetId": 0,
                 "symbol": "TEER",
                 "precision": 12,
-                "priceId": "integritee",
                 "icon": "TEER.svg"
             }
         ],
@@ -4403,7 +4356,6 @@
                 "assetId": 7,
                 "symbol": "ZTG",
                 "precision": 10,
-                "priceId": "zeitgeist",
                 "type": "orml",
                 "icon": "ZTG.svg",
                 "typeExtras": {
@@ -4543,7 +4495,6 @@
                 "assetId": 17,
                 "symbol": "INTR",
                 "precision": 10,
-                "priceId": "interlay",
                 "icon": "INTR.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -4557,7 +4508,6 @@
                 "assetId": 18,
                 "symbol": "SUB",
                 "precision": 10,
-                "priceId": "subsocial",
                 "icon": "SUB.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -4708,7 +4658,6 @@
                 "assetId": 29,
                 "symbol": "DED",
                 "precision": 10,
-                "priceId": "dot-is-ded",
                 "type": "orml",
                 "icon": "DED.svg",
                 "typeExtras": {
@@ -4775,7 +4724,6 @@
                 "symbol": "KILT",
                 "precision": 15,
                 "type": "orml",
-                "priceId": "kilt-protocol",
                 "icon": "KILT.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x1c000000",
@@ -5389,7 +5337,6 @@
                 "assetId": 0,
                 "symbol": "INTR",
                 "precision": 10,
-                "priceId": "interlay",
                 "icon": "INTR.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -5437,7 +5384,6 @@
                 "assetId": 3,
                 "symbol": "KINT",
                 "precision": 12,
-                "priceId": "kintsugi",
                 "icon": "KINT.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -5479,7 +5425,6 @@
                 "assetId": 6,
                 "symbol": "LDOT",
                 "precision": 10,
-                "priceId": "liquid-staking-dot",
                 "icon": "LDOT.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -5908,7 +5853,6 @@
             {
                 "assetId": 0,
                 "symbol": "PDEX",
-                "priceId": "polkadex",
                 "staking": [
                     "relaychain"
                 ],
@@ -5979,7 +5923,6 @@
                 "assetId": 6,
                 "symbol": "DED",
                 "precision": 12,
-                "priceId": "dot-is-ded",
                 "type": "statemine",
                 "icon": "DED.svg",
                 "typeExtras": {
@@ -6195,7 +6138,6 @@
                 "assetId": 6,
                 "symbol": "vGLMR",
                 "precision": 18,
-                "priceId": "voucher-glmr",
                 "type": "orml",
                 "icon": "vGLMR.svg",
                 "typeExtras": {
@@ -6431,7 +6373,6 @@
             {
                 "assetId": 0,
                 "symbol": "MGX",
-                "priceId": "mangata-x",
                 "precision": 18,
                 "icon": "MGX.svg",
                 "type": "orml",
@@ -6474,7 +6415,6 @@
                 "assetId": 3,
                 "symbol": "TUR",
                 "precision": 10,
-                "priceId": "turing-network",
                 "icon": "TUR.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -6516,7 +6456,6 @@
                 "assetId": 6,
                 "symbol": "ZLK",
                 "precision": 18,
-                "priceId": "zenlink-network-token",
                 "icon": "ZLK.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -7248,7 +7187,6 @@
                 "assetId": 0,
                 "symbol": "MYRIA",
                 "precision": 18,
-                "priceId": "myriad-social",
                 "icon": "MYRIA.svg"
             }
         ],
@@ -7275,7 +7213,6 @@
                 "assetId": 0,
                 "symbol": "TAO",
                 "precision": 18,
-                "priceId": "fusotao",
                 "icon": "TAO_fusotao.svg"
             }
         ],
@@ -7988,7 +7925,6 @@
             {
                 "assetId": 0,
                 "symbol": "MATIC",
-                "priceId": "matic-network",
                 "type": "evmNative",
                 "icon": "MATIC.svg",
                 "precision": 18
@@ -8032,7 +7968,6 @@
             {
                 "assetId": 0,
                 "symbol": "SAMA",
-                "priceId": "exosama-network",
                 "type": "evmNative",
                 "icon": "SAMA.svg",
                 "precision": 18
@@ -8077,7 +8012,6 @@
                 "assetId": 0,
                 "symbol": "P3D",
                 "precision": 12,
-                "priceId": "3dpass",
                 "icon": "P3D.svg"
             }
         ],
@@ -8886,7 +8820,6 @@
                 "assetId": 0,
                 "symbol": "INTR",
                 "precision": 10,
-                "priceId": "interlay",
                 "icon": "INTR.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -8928,7 +8861,6 @@
                 "assetId": 3,
                 "symbol": "KINT",
                 "precision": 12,
-                "priceId": "kintsugi",
                 "icon": "KINT.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -8970,7 +8902,6 @@
                 "assetId": 6,
                 "symbol": "LDOT",
                 "precision": 10,
-                "priceId": "liquid-staking-dot",
                 "icon": "LDOT.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -9094,7 +9025,6 @@
                 "assetId": 0,
                 "symbol": "KREST",
                 "precision": 18,
-                "priceId": "krest",
                 "icon": "KREST.svg"
             }
         ],
@@ -9453,7 +9383,6 @@
             {
                 "assetId": 0,
                 "symbol": "JOY",
-                "priceId": "joystream",
                 "precision": 10,
                 "icon": "JOY.svg",
                 "staking": [
@@ -9504,7 +9433,6 @@
             {
                 "assetId": 0,
                 "symbol": "DOCK",
-                "priceId": "dock",
                 "precision": 6,
                 "icon": "DOCK.svg",
                 "staking": [
@@ -9819,7 +9747,6 @@
                 "assetId": 0,
                 "symbol": "CGT",
                 "precision": 18,
-                "priceId": "curio-governance",
                 "icon": "CGT.svg"
             }
         ],
@@ -10049,7 +9976,6 @@
                 "assetId": 0,
                 "symbol": "BRIDGE",
                 "precision": 12,
-                "priceId": "hyperbridge-2",
                 "icon": "BRIDGE.svg"
             }
         ],
@@ -10634,7 +10560,6 @@
                 "assetId": 0,
                 "symbol": "LAOS",
                 "precision": 18,
-                "priceId": "laos-network",
                 "icon": "LAOS.svg"
             }
         ],
@@ -10865,7 +10790,6 @@
                 "assetId": 0,
                 "symbol": "TNT",
                 "precision": 18,
-                "priceId": "tangle-network",
                 "icon": "TNT.svg"
             }
         ],
@@ -11054,7 +10978,6 @@
                 "assetId": 0,
                 "symbol": "AGC",
                 "precision": 18,
-                "priceId": "argocoin-2",
                 "icon": "AGC.svg"
             }
         ],
@@ -11085,7 +11008,6 @@
                 "assetId": 0,
                 "symbol": "TANSSI",
                 "precision": 12,
-                "priceId": "tanssi",
                 "icon": "TANSSI.svg"
             }
         ],


### PR DESCRIPTION
## What

Removes `priceId` from every asset in `chains/v22` whose Coingecko price history comes back empty
for the period the Android app requests by default.

- 42 distinct `priceId` values
- **73 asset entries** in `chains.json`, **78** in `chains_dev.json` (151 lines)
- No other files in `chains/v22` were affected (`preConfigured/**` contains none of these ids)

## Why

The price proxy answers **HTTP 200 with an empty `prices` array** for these coins at `days=1`:

```
GET https://tokens-price.novasama-tech.org/api/v3/coins/kilt-protocol/market_chart?vs_currency=usd&days=1
-> {"prices": []}
```

The Android app treats that as a successfully loaded, drawable chart and crashes on opening the
asset details screen with `NoSuchElementException: List is empty` — see **NW-2133**. `days=1` is the
period selected by default, so the crash happens immediately on open.

Every `priceId` in `chains/v22` (90 files, 111 unique ids) was probed against that endpoint;
these 42 are the complete set that returns an empty array.

## ⚠️ Trade-off reviewers must be aware of

**This is not a set of dead coins, and `priceId` drives more than the chart.**

Coingecko serves 5-minutely granularity for `days=1` and returns an empty array for coins with no
trades in the last 24h. **40 of these 42 ids still have a working live spot price**, and most have
plenty of history at `days=30` / `days=max`. Removing `priceId` also removes the **fiat price and
fiat balance** for the asset, not just the chart.

Concretely, this PR gives up live fiat pricing for assets including **KILT, MATIC, Shiden, Polkadex,
Interlay, Kintsugi, Zeitgeist, Quartz, Basilisk, Altair, Subsocial, Tanssi and Picasso** in order to
avoid a client-side crash. The alternative is to fix the empty-list handling in the app (NW-2133)
and keep the config as is.

Only two entries in the set are genuinely dataless: `tangle-network` (0 points at every period, no
spot price, chain is PAUSED) and — separately, not part of this PR — `usdc`, which is not a valid
Coingecko id at all (404) and should be repointed to `usd-coin` for USDC.s on Pendulum.

## Full set

<details>
<summary>42 priceIds with measured data availability</summary>

| priceId | symbols | prod | dev | days=30 | days=max | live spot USD |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| `3dpass` | P3D | 1 | 1 | 0 | 890 | 0.00098797 |
| `altair` | AIR | 2 | 2 | 0 | 1536 | 0.0008878 |
| `argocoin-2` | AGC | 1 | 1 | 0 | 149 | 0.0141061 |
| `ausd-seed-acala` | aSEEDp, xcaSEEDp | 3 | 3 | 439 | 707 | 0.0308209 |
| `basilisk` | BSX | 2 | 2 | 0 | 1386 | 1.066e-05 |
| `calamari-network` | KMA, xcKMA | 2 | 2 | 0 | 1200 | 5.958e-05 |
| `crust-storage-market` | CSM, xcCSM | 4 | 4 | 0 | 1628 | 0.002606 |
| `curio-governance` | CGT | 1 | 1 | 0 | 929 | 0.0398633 |
| `darwinia-crab-network` | CRAB, xcCRAB | 2 | 2 | 0 | 411 | 0.0009526 |
| `dock` | DOCK | 1 | 1 | 0 | 2553 | 0.00274507 |
| `dot-is-ded` | DED | 3 | 3 | 64 | 359 | 1.04e-06 |
| `edgeware` | EDG | 1 | 1 | 0 | 2081 | 1.247e-05 |
| `equilibrium-token` | EQ, xcEQ | 2 | 2 | 0 | 1088 | 1.2e-06 |
| `exosama-network` | SAMA | 1 | 1 | 38 | 1290 | 0.00034883 |
| `fusotao` | TAO | 0 | 1 | 0 | 1368 | 212.73 |
| `genshiro` | GENS | 1 | 1 | 0 | 1426 | 1.301e-05 |
| `hyperbridge-2` | BRIDGE | 1 | 1 | 0 | 129 | 0.00607997 |
| `integritee` | TEER, xcTEER | 3 | 3 | 0 | 1623 | 0.00369558 |
| `interlay` | INTR, xcINTR | 5 | 6 | 371 | 1416 | 0.00011914 |
| `joystream` | JOY | 1 | 1 | 0 | 1010 | 0.00143586 |
| `kilt-protocol` | KILT | 2 | 2 | 0 | 1316 | 0.0176568 |
| `kintsugi` | KINT, xcKINT | 5 | 6 | 61 | 1593 | 0.00130411 |
| `krest` | KREST | 1 | 1 | 0 | 928 | 0.00984966 |
| `laos-network` | LAOS | 1 | 1 | 0 | 289 | 0.00100007 |
| `liquid-staking-dot` | LDOT | 3 | 4 | 209 | 900 | 0.142902 |
| `mangata-x` | MGX, xcMGX | 2 | 2 | 0 | 552 | 3.924e-05 |
| `matic-network` | MATIC | 0 | 1 | 0 | 2389 | 0.126156 |
| `metaverse-network-pioneer` | NEER | 1 | 1 | 0 | 914 | 0.00655866 |
| `my-paqman-coin` | MPC | 1 | 1 | 0 | 408 | 1.81e-06 |
| `myriad-social` | MYRIA | 1 | 1 | 0 | 1085 | 1.375e-05 |
| `paydon` | DON | 1 | 1 | 0 | 291 | 0.00710645 |
| `picasso` | PICA | 1 | 1 | 459 | 1092 | 2.2e-06 |
| `polkadex` | PDEX | 1 | 1 | 31 | 1825 | 0.698389 |
| `quartz` | QTZ | 2 | 2 | 0 | 1325 | 1.027e-05 |
| `shiden` | SDN, xcSDN | 2 | 2 | 0 | 1736 | 0.00690796 |
| `subsocial` | SUB | 2 | 2 | 1 | 747 | 3.575e-05 |
| `tangle-network` | TNT | 1 | 1 | 0 | 0 | **none** |
| `tanssi` | TANSSI | 1 | 1 | 143 | 382 | 4.108e-05 |
| `turing-network` | TUR, xcTUR | 2 | 2 | 0 | 508 | 0.0005791 |
| `voucher-glmr` | vGLMR, xcvGLMR | 2 | 2 | 30 | 483 | 0.00950868 |
| `zeitgeist` | ZTG | 2 | 2 | 0 | 1163 | 0.00335734 |
| `zenlink-network-token` | ZLK | 2 | 2 | 0 | 1640 | 0.0267038 |

</details>

## Verification

- Both files re-parse as valid JSON after the edit.
- The parsed result was deep-compared against the original with exactly these `priceId` keys
  dropped — no other value changed.
- The 4 insertions in the diff are trailing-comma fixes for `SDN` and `AIR`, where `priceId` was the
  last key in the asset object.
