### PR TITLE
prod: promote HOLLAR on Polkadot Asset Hub + Hydration <> Asset Hub transfers

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -3259,6 +3259,19 @@
                 "typeExtras": {
                     "assetId": "50000111"
                 }
+            },
+            {
+                "assetId": 28,
+                "symbol": "HOLLAR",
+                "precision": 18,
+                "priceId": "hydrated-dollar",
+                "type": "statemine",
+                "icon": "HOLLAR.svg",
+                "typeExtras": {
+                    "assetId": "0x010200c91f057903",
+                    "palletName": "ForeignAssets",
+                    "isSufficient": true
+                }
             }
         ],
         "nodes": [
@@ -4834,7 +4847,7 @@
                 "assetId": 65,
                 "symbol": "HOLLAR",
                 "precision": 18,
-                "priceId": "tether",
+                "priceId": "hydrated-dollar",
                 "type": "orml-hydration-evm",
                 "icon": "HOLLAR.svg",
                 "typeExtras": {

--- a/xcm/v8/transfers.json
+++ b/xcm/v8/transfers.json
@@ -425,6 +425,20 @@
         },
         "instructions": "xtokensReserve"
       }
+    },
+    "HOLLAR": {
+      "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+      "multiLocation": {
+        "parachainId": 2034,
+        "generalIndex": "222"
+      },
+      "reserveFee": {
+        "mode": {
+          "type": "proportional",
+          "value": "2000000000000000000"
+        },
+        "instructions": "xtokensReserve"
+      }
     }
   },
   "instructions": {
@@ -2004,6 +2018,29 @@
               "type": "xcmpallet"
             }
           ]
+        },
+        {
+          "assetId": 28,
+          "assetLocation": "HOLLAR",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+                "assetId": 65,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "3000000000000000000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
+            }
+          ]
         }
       ]
     },
@@ -2265,6 +2302,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "70000000000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 65,
+          "assetLocation": "HOLLAR",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+                "assetId": 28,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "650000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
Promotes the dev-only config from #4380 to production, with the **Hydration → Asset Hub
fee coefficient corrected** against measured on-chain execution cost.

Verified end-to-end on device against a `10.9.0-debug` build (which reads the dev configs),
with real mainnet transfers on the `hhhd` wallet.

### Changes

**`chains/v22/chains.json`**
- HOLLAR (assetId 28) on Polkadot Asset Hub — `ForeignAssets` `0x010200c91f057903`, 18 decimals, `isSufficient`
- Hydration HOLLAR (assetId 65): `priceId` `tether` → `hydrated-dollar`

**`xcm/v8/transfers.json`**
- HOLLAR asset location + both transfer directions (legacy config, mirroring MYTH)
- **Hydration → PAH fee `2000000000000000000` → `650000000000000000`**

### Fee correction

#4380 assumed a PAH destination cost of 0.0037 HOLLAR and applied ~2× headroom. Measured
against real transfers the actual cost is **0.00132**, so the coefficient was charging
0.008 HOLLAR — **6.1×** rather than the intended 2×.

| Direction | Old fee | New fee | Measured cost | Headroom |
|---|---|---|---|---|
| Hydration → PAH | 0.0080 | **0.0026** | 0.00132 | 1.97× |
| PAH → Hydration | 0.0012 | 0.0012 (unchanged) | 0.00071 | 1.69× |

Fee model is `weight × unitsPerSecond / 1e12` with `weight = networkBaseWeight[dest] × |instructions|`,
i.e. `4e9 × 6.5e17 / 1e12 = 2.6e15` = 0.0026 HOLLAR.

No funds were at risk from the old value — surplus is returned to the beneficiary by
`DepositAsset` — but the over-estimate inflated the displayed cross-chain fee and the
reserved max transferable amount.
