### PR TITLE
Create staking announcements dev config

### DIFF
--- a/announcements/v1/announcements_dev.json
+++ b/announcements/v1/announcements_dev.json
@@ -1,7 +1,7 @@
 {
   "staking": [
     {
-      "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f"
+      "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
       "style": "error",
       "description": {
         "default": "Rewards in DOT staking will resume after the migration completes. Please wait.",

--- a/announcements/v1/announcements_dev.json
+++ b/announcements/v1/announcements_dev.json
@@ -12,8 +12,8 @@
       "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
       "style": "info",
       "description": {
-        "default": "I've ate",
-        "ru": "Я покушал"
+        "default": "Kusama staking is temporary deactivated",
+        "ru": "Kusama-стейкинг временно неактивен"
       }
     },
     {

--- a/announcements/v1/announcements_dev.json
+++ b/announcements/v1/announcements_dev.json
@@ -3,8 +3,8 @@
     {
       "style": "warning",
       "description": {
-        "default": "Rewards will resume after the migration completes.",
-        "ru": "Награды возобновятся после завершения миграции."
+        "default": "Rewards in DOT staking will resume after the migration completes. Please wait.",
+        "ru": "Награды DOT-стейкинга возобновятся после завершения миграции. пожалуйста ожидайте"
       }
     }
   ]

--- a/announcements/v1/announcements_dev.json
+++ b/announcements/v1/announcements_dev.json
@@ -1,0 +1,11 @@
+{
+  "staking": [
+    {
+      "style": "warning",
+      "description": {
+        "default": "Rewards will resume after the migration completes.",
+        "ru": "Награды возобновятся после завершения миграции."
+      }
+    }
+  ]
+}

--- a/announcements/v1/announcements_dev.json
+++ b/announcements/v1/announcements_dev.json
@@ -1,7 +1,7 @@
 {
   "staking": [
     {
-      "style": "warning",
+      "style": "error",
       "description": {
         "default": "Rewards in DOT staking will resume after the migration completes. Please wait.",
         "ru": "Награды DOT-стейкинга возобновятся после завершения миграции. пожалуйста ожидайте"

--- a/announcements/v1/announcements_dev.json
+++ b/announcements/v1/announcements_dev.json
@@ -10,9 +10,10 @@
     },
     {
       "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+      "style": "info",
       "description": {
-        "default": "Rewards in KSM staking will resume after the migration completes. Please wait.",
-        "ru": "Награды KSM-стейкинга возобновятся после завершения миграции. пожалуйста ожидайте"
+        "default": "I've ate",
+        "ru": "Я покушал"
       }
     },
     {

--- a/announcements/v1/announcements_dev.json
+++ b/announcements/v1/announcements_dev.json
@@ -1,10 +1,25 @@
 {
   "staking": [
     {
+      "chainId": "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f"
       "style": "error",
       "description": {
         "default": "Rewards in DOT staking will resume after the migration completes. Please wait.",
         "ru": "Награды DOT-стейкинга возобновятся после завершения миграции. пожалуйста ожидайте"
+      }
+    },
+    {
+      "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+      "description": {
+        "default": "Rewards in KSM staking will resume after the migration completes. Please wait.",
+        "ru": "Награды KSM-стейкинга возобновятся после завершения миграции. пожалуйста ожидайте"
+      }
+    },
+    {
+      "style": "error",
+      "description": {
+        "default": "Rewards in DOT and KSM staking will resume after the migration completes. Please wait.",
+        "ru": "Награды KSM и DOT-стейкинга возобновятся после завершения миграции. пожалуйста ожидайте"
       }
     }
   ]


### PR DESCRIPTION
Adds `announcements/v1/announcements_dev.json` — a new remote source that lets us show a message on the staking dashboard without shipping an app release.

Dev only, per the dev → prod flow. The prod file will come in a separate PR once the client change is merged.

## Format

```json
{
  "staking": [
    {
      "style": "warning",
      "description": {
        "default": "Rewards will resume after the migration completes.",
        "ru": "Награды возобновятся после завершения миграции."
      }
    }
  ]
}
```

- Top-level keys are **sections**. Only `staking` is read today; adding another section later needs no format change and no new file.
- `style` is optional — `info`, `warning` or `error`, defaulting to `info` when absent or unrecognised.
- `description` holds one entry per language. `default` is the English copy; every other key is an ISO 639-1 code. If the user's language is missing, `default` is used.
- Several announcements can be listed in a section; they render one under another.

## Note on the content

The message above is sample copy so the client can be verified end to end on dev. Replace or empty the array (`"staking": []`) before this gets promoted to prod.

The Android side is not merged yet, so nothing reads this file until then. A missing or malformed file is handled quietly — the dashboard just shows no announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)