### PR TITLE
DApp Catalog Changes

### DIFF
--- a/dapps/dapps.json
+++ b/dapps/dapps.json
@@ -19,9 +19,6 @@
       "url": "https://polkadot.js.org/apps/"
     },
     {
-      "url": "https://ramp.harbour.fi/polkadot"
-    },
-    {
       "url": "https://app.hyperbridge.network/"
     }
   ],
@@ -45,21 +42,6 @@
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/categories/color/Governance.svg",
       "name": "Governance",
       "id": "governance"
-    },
-    {
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/categories/color/Art.svg",
-      "name": "Art",
-      "id": "art"
-    },
-    {
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/categories/color/Gaming.svg",
-      "name": "Gaming",
-      "id": "gaming"
-    },
-    {
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/categories/color/Social.svg",
-      "name": "Social",
-      "id": "social"
     },
     {
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/categories/color/Utilities.svg",
@@ -132,30 +114,12 @@
       ]
     },
     {
-      "name": "ArthSwap",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/ArthSwap.svg",
-      "url": "https://app.arthswap.org/#/swap",
-      "categories": [
-        "dex",
-        "evm"
-      ]
-    },
-    {
       "name": "Polkadot Staking Dashboard",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/StakingDashboard.svg",
       "url": "https://staking.polkadot.cloud/#/overview",
       "categories": [
         "staking",
         "utilities"
-      ]
-    },
-    {
-      "name": "Basilisk Snek Swap",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/SnekSwap.svg",
-      "url": "https://app.basilisk.cloud/",
-      "categories": [
-        "bridge",
-        "dex"
       ]
     },
     {
@@ -184,15 +148,6 @@
       ]
     },
     {
-      "name": "OpenSea",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/OpenSea.svg",
-      "url": "https://opensea.io/",
-      "categories": [
-        "art",
-        "evm"
-      ]
-    },
-    {
       "name": "Polkadot Bounties",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/PolkadotBounties.svg",
       "url": "https://bounties.usepapi.app/",
@@ -217,14 +172,6 @@
         "dex",
         "evm",
         "staking"
-      ]
-    },
-    {
-      "name": "WUD Universe",
-      "url": "https://wuduniverse.xyz/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/WudUniverse.png",
-      "categories": [
-        "art"
       ]
     },
     {

--- a/dapps/dapps_dev.json
+++ b/dapps/dapps_dev.json
@@ -19,9 +19,6 @@
       "url": "https://polkadot.js.org/apps/"
     },
     {
-      "url": "https://ramp.harbour.fi/polkadot"
-    },
-    {
       "url": "https://app.hyperbridge.network/"
     }
   ],
@@ -45,11 +42,6 @@
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/categories/color/Governance.svg",
       "name": "Governance",
       "id": "governance"
-    },
-    {
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/categories/color/Art.svg",
-      "name": "Art",
-      "id": "art"
     },
     {
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/categories/color/Gaming.svg",
@@ -144,30 +136,12 @@
       ]
     },
     {
-      "name": "ArthSwap",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/ArthSwap.svg",
-      "url": "https://app.arthswap.org/#/swap",
-      "categories": [
-        "dex",
-        "evm"
-      ]
-    },
-    {
       "name": "Polkadot Staking Dashboard",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/StakingDashboard.svg",
       "url": "https://staking.polkadot.cloud/#/overview",
       "categories": [
         "staking",
         "utilities"
-      ]
-    },
-    {
-      "name": "Basilisk Snek Swap",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/SnekSwap.svg",
-      "url": "https://app.basilisk.cloud/",
-      "categories": [
-        "bridge",
-        "dex"
       ]
     },
     {
@@ -231,15 +205,6 @@
       "categories": [
         "utilities",
         "test"
-      ]
-    },
-    {
-      "name": "OpenSea",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/OpenSea.svg",
-      "url": "https://opensea.io/",
-      "categories": [
-        "art",
-        "evm"
       ]
     },
     {
@@ -312,14 +277,6 @@
         "dex",
         "evm",
         "staking"
-      ]
-    },
-    {
-      "name": "WUD Universe",
-      "url": "https://wuduniverse.xyz/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/WudUniverse.png",
-      "categories": [
-        "art"
       ]
     }
   ]

--- a/dapps/dapps_full.json
+++ b/dapps/dapps_full.json
@@ -19,9 +19,6 @@
       "url": "https://polkadot.js.org/apps/"
     },
     {
-      "url": "https://ramp.harbour.fi/polkadot"
-    },
-    {
       "url": "https://app.hyperbridge.network/"
     }
   ],
@@ -45,21 +42,6 @@
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/categories/color/Governance.svg",
       "name": "Governance",
       "id": "governance"
-    },
-    {
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/categories/color/Art.svg",
-      "name": "Art",
-      "id": "art"
-    },
-    {
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/categories/color/Gaming.svg",
-      "name": "Gaming",
-      "id": "gaming"
-    },
-    {
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/categories/color/Social.svg",
-      "name": "Social",
-      "id": "social"
     },
     {
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/categories/color/Utilities.svg",
@@ -132,30 +114,12 @@
       ]
     },
     {
-      "name": "ArthSwap",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/ArthSwap.svg",
-      "url": "https://app.arthswap.org/#/swap",
-      "categories": [
-        "dex",
-        "evm"
-      ]
-    },
-    {
       "name": "Polkadot Staking Dashboard",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/StakingDashboard.svg",
       "url": "https://staking.polkadot.cloud/#/overview",
       "categories": [
         "staking",
         "utilities"
-      ]
-    },
-    {
-      "name": "Basilisk Snek Swap",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/SnekSwap.svg",
-      "url": "https://app.basilisk.cloud/",
-      "categories": [
-        "bridge",
-        "dex"
       ]
     },
     {
@@ -184,15 +148,6 @@
       ]
     },
     {
-      "name": "OpenSea",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/OpenSea.svg",
-      "url": "https://opensea.io/",
-      "categories": [
-        "art",
-        "evm"
-      ]
-    },
-    {
       "name": "Polkadot Bounties",
       "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/PolkadotBounties.svg",
       "url": "https://bounties.usepapi.app/",
@@ -217,14 +172,6 @@
         "dex",
         "evm",
         "staking"
-      ]
-    },
-    {
-      "name": "WUD Universe",
-      "url": "https://wuduniverse.xyz/",
-      "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/dapps/dapps/color/WudUniverse.png",
-      "categories": [
-        "art"
       ]
     },
     {


### PR DESCRIPTION
### Removed dApps

- **Basilisk Snek Swap** — low user activity and low liquidity
- **ArthSwap** — low user activity and low liquidity
- **OpenSea & WUD Universe** — the Art, Gaming and Social categories need an overall review regarding user activity, engagement and popularity; removing these last entries while that review happens

### Knock-on changes

- The **Art**, **Gaming** and **Social** category declarations are dropped from the prod catalog — Gaming and Social were already empty, and Art empties with this change. (`dapps_dev.json` keeps `gaming`/`social` declared, as the staged dev-only entries — Mythos Foundation, V-Starship — still reference them.)
- Removed the `ramp.harbour.fi/polkadot` popular entry — a pre-existing dangling reference with no matching `dapps[]` entry. Popular carousel 8 → 7.

Catalog: 19 → 15 dApps, 9 → 6 categories. Pure deletions (−149 lines); README regeneration left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
