### PR TITLE
Fix HOLLAR existential deposit on Hydration

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -4840,7 +4840,7 @@
                 "typeExtras": {
                     "currencyIdScale": "0xde000000",
                     "currencyIdType": "u32",
-                    "existentialDeposit": "0",
+                    "existentialDeposit": "20000000000000000",
                     "transfersEnabled": true
                 }
             },

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -5163,7 +5163,7 @@
                 "typeExtras": {
                     "currencyIdScale": "0xde000000",
                     "currencyIdType": "u32",
-                    "existentialDeposit": "0",
+                    "existentialDeposit": "20000000000000000",
                     "transfersEnabled": true
                 }
             },


### PR DESCRIPTION
## Summary
HOLLAR (currencyId 222, `orml-hydration-evm`) on Hydration has `existentialDeposit: "0"` in both `chains.json` and `chains_dev.json`, while on-chain `assetRegistry.assets(222)` returns `existentialDeposit = 20_000_000_000_000_000` (0.02 HOLLAR, `isSufficient: true`).

The Android client reads the ED for orml assets straight from `typeExtras` (`OrmlAssetBalance.existentialDeposit`), so ED validations for HOLLAR on Hydration currently check against 0.

## Related
- novasamatech/nova-wallet-android#2311 — HOLLAR on Polkadot Asset Hub was already added to dev in #4380 (`foreignAssets` key `0x010200c91f057903`, verified against chain: `{parents:1, X2[Parachain 2034, GeneralIndex 222]}`, minBalance 0.02, sufficient). This PR only fixes the Hydration ED; AH promotion to prod happens with the regular dev→prod apply.