### PR TITLE
Remove Subscan block explorer from Hydration

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -4996,11 +4996,6 @@
         ],
         "explorers": [
             {
-                "name": "Subscan",
-                "extrinsic": "https://hydration.subscan.io/extrinsic/{hash}",
-                "account": "https://hydration.subscan.io/account/{address}"
-            },
-            {
                 "name": "Neckwork",
                 "extrinsic": "https://hydration-explorer.neckwork.net/extrinsic/{hash}",
                 "account": "https://hydration-explorer.neckwork.net/account/{address}",

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -5306,11 +5306,6 @@
         ],
         "explorers": [
             {
-                "name": "Subscan",
-                "extrinsic": "https://hydration.subscan.io/extrinsic/{hash}",
-                "account": "https://hydration.subscan.io/account/{address}"
-            },
-            {
                 "name": "Neckwork",
                 "extrinsic": "https://hydration-explorer.neckwork.net/extrinsic/{hash}",
                 "account": "https://hydration-explorer.neckwork.net/account/{address}",


### PR DESCRIPTION
## Summary
Removes the Subscan block explorer from the Hydration entry in `chains/v22/chains.json` and `chains/v22/chains_dev.json`.

The Hydration team has informed us that Subscan is sunsetting its Hydration support within the next 24 hours, after which `hydration.subscan.io` will stop serving data. The Neckwork explorer added in #4354 remains as Hydration's block explorer, so explorer links in the app continue to work.

Both dev and prod configs are updated together (as in #4354) given the short sunset window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)