### PR TITLE
Set Hydration defaultBlockTime to 2s

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -5028,7 +5028,7 @@
         "additional": {
             "feeViaRuntimeCall": true,
             "supportsGenericLedgerApp": true,
-            "defaultBlockTime": 6000
+            "defaultBlockTime": 2000
         },
         "legacyAddressPrefix": 63
     },

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -5338,7 +5338,7 @@
         "additional": {
             "feeViaRuntimeCall": true,
             "supportsGenericLedgerApp": true,
-            "defaultBlockTime": 6000
+            "defaultBlockTime": 2000
         },
         "legacyAddressPrefix": 63
     },


### PR DESCRIPTION
Hydration now produces blocks every 2 seconds, so the configured `defaultBlockTime` of 6000 ms is stale.

- `chains/v22/chains.json` — Hydration `additional.defaultBlockTime`: `6000` → `2000`
- `chains/v22/chains_dev.json` — same change