### PR TITLE
fix: remove Polkadot Hub TestNet, it has no wss nodes left

### DIFF
--- a/chains/v22/chains.json
+++ b/chains/v22/chains.json
@@ -8785,51 +8785,6 @@
         }
     },
     {
-        "chainId": "eip155:420420422",
-        "name": "Polkadot Hub TestNet (PAUSED)",
-        "assets": [
-            {
-                "assetId": 0,
-                "symbol": "PAS",
-                "type": "evmNative",
-                "icon": "PAS.svg",
-                "precision": 18
-            }
-        ],
-        "nodeSelectionStrategy": "uniform",
-        "nodes": [
-            {
-                "url": "https://testnet-passet-hub-eth-rpc.polkadot.io",
-                "name": "Polkadot Hub rpc node"
-            }
-        ],
-        "explorers": [
-            {
-                "name": "Blockscan",
-                "extrinsic": "https://blockscout-passet-hub.parity-testnet.parity.io/tx/{hash}",
-                "account": "https://blockscout-passet-hub.parity-testnet.parity.io/address/{address}"
-            }
-        ],
-        "externalApi": {
-            "history": [
-                {
-                    "type": "etherscan",
-                    "url": "https://blockscout-passet-hub.parity-testnet.parity.io/api/v2/",
-                    "parameters": {
-                        "assetType": "evm"
-                    }
-                }
-            ]
-        },
-        "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Paseo_Testnet.svg",
-        "addressPrefix": 420420422,
-        "options": [
-            "ethereumBased",
-            "noSubstrateRuntime",
-            "testnet"
-        ]
-    },
-    {
         "chainId": "4b5f95eefedf0d0fb514339edc24d2d411310520f687b4146145bcedb99885b9",
         "parentId": "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
         "name": "Acurast",

--- a/chains/v22/chains_dev.json
+++ b/chains/v22/chains_dev.json
@@ -10998,51 +10998,6 @@
         "addressPrefix": 74
     },
     {
-        "chainId": "eip155:420420422",
-        "name": "Polkadot Hub TestNet (PAUSED)",
-        "assets": [
-            {
-                "assetId": 0,
-                "symbol": "PAS",
-                "type": "evmNative",
-                "icon": "PAS.svg",
-                "precision": 18
-            }
-        ],
-        "nodeSelectionStrategy": "uniform",
-        "nodes": [
-            {
-                "url": "https://testnet-passet-hub-eth-rpc.polkadot.io",
-                "name": "Polkadot Hub rpc node"
-            }
-        ],
-        "explorers": [
-            {
-                "name": "Blockscan",
-                "extrinsic": "https://blockscout-passet-hub.parity-testnet.parity.io/tx/{hash}",
-                "account": "https://blockscout-passet-hub.parity-testnet.parity.io/address/{address}"
-            }
-        ],
-        "externalApi": {
-            "history": [
-                {
-                    "type": "etherscan",
-                    "url": "https://blockscout-passet-hub.parity-testnet.parity.io/api/v2/",
-                    "parameters": {
-                        "assetType": "evm"
-                    }
-                }
-            ]
-        },
-        "icon": "https://raw.githubusercontent.com/novasamatech/nova-utils/master/icons/chains/gradient/Paseo_Testnet.svg",
-        "addressPrefix": 420420422,
-        "options": [
-            "ethereumBased",
-            "noSubstrateRuntime",
-            "testnet"
-        ]
-    },
-    {
         "chainId": "4b5f95eefedf0d0fb514339edc24d2d411310520f687b4146145bcedb99885b9",
         "parentId": "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
         "name": "Acurast",


### PR DESCRIPTION
## What

Removes **Polkadot Hub TestNet** (`eip155:420420422`) from `chains/v22/chains.json` and `chains/v22/chains_dev.json`.

This is a production hotfix: in its current state the entry breaks the Assets screen of Nova Wallet Android for **every** user, on **every** network — not just this one.

## Why

#4389 removed `wss://passet-hub-paseo.ibp.network` (the IBP host no longer resolves). That left the network with one `https://` endpoint and **zero wss nodes**:

```json
"nodes": [
    { "url": "https://testnet-passet-hub-eth-rpc.polkadot.io", "name": "Polkadot Hub rpc node" }
]
```

It is the only chain in v22 in that state — before #4389 every chain in the prod config had at least one wss node.

## How one chain takes down the whole wallet

The Android client cannot survive a chain with no wss nodes:

1. `NodeAutobalancer.connectionUrlFlow` builds the node iterator and, when it is empty, `return@transformLatest`s — **emitting nothing**:

   ```kotlin
   if (!nodeIterator.hasNext()) {
       Log.w(LOG_TAG, "No wss nodes available for chain $chainId using strategy $strategy")
       return@transformLatest
   }
   ```

2. `ChainConnection.observeCurrentNode()` awaits that first emission — `currentUrl.first()` — so `setup()` **suspends forever**.

3. That await sits inside the `map` block of `ChainRegistry.currentChains`, which registers chains sequentially:

   ```kotlin
   val currentChains = chainDao.joinChainInfoFlow()
       .mapList { mapChainLocalToChain(it, gson) }
       .diffed()
       .map { diff ->
           diff.removed.forEach { unregisterChain(it) }
           diff.newOrUpdated.forEach { chain -> registerChain(chain) }   // <- blocks here
           diff.all
       }
   ```

So `currentChains` never emits → `chainsById` never emits → `WalletRepositoryImpl.syncedAssetsFlow` (a `combine` on `chainsById`) never emits → the Assets screen shows an **empty token list** and the total balance stays on its **loading shimmer** indefinitely. `noSubstrateRuntime` puts the chain in `FULL_SYNC`, so it is registered regardless of the user's "show testnets" setting.

Reproduced on a release build, `10.9.2-market`:

```
W NodeAutobalancer: No wss nodes available for chain eip155:420420422 using strategy
  io.novafoundation.nova.runtime.multiNetwork.connection.autobalance.strategy.UniformGenerator@32d21a2
```

## Why removal rather than a backfill

- The network is already marked `(PAUSED)`.
- It is a testnet (`"options": ["ethereumBased", "noSubstrateRuntime", "testnet"]`).
- No third-party wss endpoint for `passet-hub-paseo` exists — `polkadot-js` has dropped the IBP/dotters entries too, which is what #4389 acted on.

Keeping it with an https-only node list is not an option while the client behaves this way.

## Verification

- Both files parse; no other chain touched (45 deleted lines per file, nothing else).
- Re-checked both configs: **no chain is left with zero wss nodes and none has an empty node list** (`chains.json` 97 networks, `chains_dev.json` 137).
- `chainId` `eip155:420420422` appears nowhere else in the repo — no xcm, dapps or preConfigured references to clean up.
- `chains/README.md` is intentionally not touched: `update_network_list.yaml` regenerates it on push to master.

## Follow-up (client side, separate issue)

The config should not be able to deadlock the client. `NodeAutobalancer` should emit `null` instead of nothing when a chain has no wss nodes (`ChainConnection` already handles `null` via `?: return`), and/or `ChainRegistry` should not `await` per-chain connection setup inside its flow operator.
