### PR TITLE
chore: bump pre-commit-hooks to pick up the ws/wss node check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/novasamatech/pre-commit-hooks
-    rev: 60a603fc64cc2c80423aa10504b63cbe630db744
+    rev: 3a7494acccb1f444e3c1a9c988a17b2a9c862a6d
     hooks:
     -   id: check-chains-json
     -   id: check-dapps-json


### PR DESCRIPTION
## What

Bumps the pinned `novasamatech/pre-commit-hooks` rev from `60a603fc` to `3a7494ac`, which brings in novasamatech/pre-commit-hooks#5: `check-chains-json` now fails when a chain has **no `ws://` or `wss://` node**, empty node lists included.

Config-only change — one line.

## Why

#4389 dropped `wss://passet-hub-paseo.ibp.network` (the IBP host stopped resolving) and left Polkadot Hub TestNet (`eip155:420420422`) with a single `https://` endpoint. Nova Wallet Android picks a websocket node for every chain it registers; its autobalancer emits nothing when the wss list is empty, `ChainConnection.setup()` awaits that emission, and chains are registered sequentially inside one flow operator — so the whole chain registry stalled. Users saw an empty token list and a total balance stuck on its loading shimmer, on **every** network. Fixed in #4392; this is the guard that keeps it from coming back.

`check_commit_rules.yaml` runs `pre-commit` with `--all-files` on every PR to master, so the check now gates all chains configs, not just the touched ones.

## Verification

Ran locally at the new rev:

- `pre-commit run --all-files` — all six hooks pass across the whole repo (`check chains json`, `check dapps json`, `fix end of files`, `trim trailing whitespace`, `check json`, `flake8`).
- Negative test: temporarily reintroduced the removed chain, and the hook installed from this rev rejects it end-to-end —

  ```
  check chains json........................................................Failed
  chains/v22/chains.json: Found problems - (Chain 'Polkadot Hub TestNet (PAUSED)' has no ws:// or wss://
  node. Add a websocket node or remove the chain - clients cannot register a chain that only has http(s) nodes.)
  ```

No existing data needs fixing: all 51 chains configs — `chains/chains.json` through `chains/v22/`, prod and dev, plus `preConfigured` and `tests/chains_for_testBalance.json` — already satisfy the invariant.
